### PR TITLE
Stabilize DB startup, add SQLite file migrations, and begin safe server modularization

### DIFF
--- a/database.js
+++ b/database.js
@@ -4,6 +4,7 @@ const path = require("path");
 const fs = require("fs");
 const sqlite3 = require("sqlite3").verbose();
 const bcrypt = require("bcrypt");
+const { applySqliteFileMigrations } = require("./services/sqliteMigrationService");
 
 const DEFAULT_SQLITE_PATH = path.join(__dirname, "data", "dev.sqlite");
 const DB_FILE = process.env.SQLITE_PATH || process.env.DB_FILE || DEFAULT_SQLITE_PATH;
@@ -1228,6 +1229,15 @@ await run(`CREATE INDEX IF NOT EXISTS idx_appeal_messages_appeal ON appeal_messa
       UNIQUE(username, endpoint)
     )
   `);
+
+  const migrationResult = await applySqliteFileMigrations({
+    db,
+    run,
+    migrationsDir: path.join(__dirname, "migrations"),
+  });
+  if (migrationResult.applied.length) {
+    console.log(`[database] applied sqlite file migrations: ${migrationResult.applied.join(", ")}`);
+  }
 
 
 // --- Fixed role assignments

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const logger = require("../logger");
+
+function errorHandler(err, req, res, _next) {
+  logger.error("[http] unhandled error", { method: req.method, path: req.originalUrl, err });
+  if (res.headersSent) return;
+  const status = Number(err?.status || err?.statusCode) || 500;
+  const safeMessage =
+    status >= 500
+      ? "Internal server error."
+      : err?.publicMessage || err?.message || "Request failed.";
+  res.status(status).json({ message: safeMessage, error: { message: safeMessage } });
+}
+
+module.exports = {
+  errorHandler,
+};

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const express = require("express");
+
+function createHealthRoutes(getDbBackend) {
+  const router = express.Router();
+  router.get("/health", (_req, res) => {
+    res.json({ status: "ok", db: getDbBackend() });
+  });
+  return router;
+}
+
+module.exports = {
+  createHealthRoutes,
+};

--- a/server.js
+++ b/server.js
@@ -2,23 +2,26 @@
 
 // Update a user's role in SQLite (legacy) and Postgres (Render/prod) when available.
 async function setRoleEverywhere(targetId, username, role) {
-  // SQLite
-  try {
-    if (targetId != null) {
-      await dbRunAsync("UPDATE users SET role=? WHERE id=?", [role, targetId]);
-    } else if (username) {
-      await dbRunAsync("UPDATE users SET role=? WHERE lower(username)=lower(?)", [role, username]);
-    }
-  } catch (err) { logger.warn("Suppressed server error", { err }); }
-
-  // Postgres
-  try {
-    if (targetId != null) {
-      await pgPool.query("UPDATE users SET role=$1 WHERE id=$2", [role, targetId]);
-    } else if (username) {
-      await pgPool.query("UPDATE users SET role=$1 WHERE lower(username)=lower($2)", [role, username]);
-    }
-  } catch (err) { logger.warn("Suppressed server error", { err }); }
+  const writeToPostgres = shouldUsePostgresAsSourceOfTruth();
+  const writeToSqlite = !writeToPostgres;
+  if (writeToSqlite) {
+    try {
+      if (targetId != null) {
+        await dbRunAsync("UPDATE users SET role=? WHERE id=?", [role, targetId]);
+      } else if (username) {
+        await dbRunAsync("UPDATE users SET role=? WHERE lower(username)=lower(?)", [role, username]);
+      }
+    } catch (err) { logger.warn("Suppressed server error", { err }); }
+  }
+  if (writeToPostgres) {
+    try {
+      if (targetId != null) {
+        await pgPool.query("UPDATE users SET role=$1 WHERE id=$2", [role, targetId]);
+      } else if (username) {
+        await pgPool.query("UPDATE users SET role=$1 WHERE lower(username)=lower($2)", [role, username]);
+      }
+    } catch (err) { logger.warn("Suppressed server error", { err }); }
+  }
 }
 "use strict";
 
@@ -666,6 +669,9 @@ const { SURVIVAL_EVENT_TEMPLATES, SURVIVAL_ITEM_POOL } = require("./survival-eve
 const statePersistence = require("./state-persistence");
 const validators = require("./validators");
 const logger = require("./logger");
+const { resolveDbStrategy, validateStartupConnection } = require("./services/dbStrategy");
+const { createHealthRoutes } = require("./routes/healthRoutes");
+const { errorHandler } = require("./middleware/errorHandler");
 
 // DnD modules
 const dndCharacterSystem = require("./dnd/character-system");
@@ -707,6 +713,7 @@ try {
   logger.error("[startup] env validation failed", { err });
   process.exit(1);
 }
+const STARTUP_DB_STRATEGY = resolveDbStrategy({ hasDatabaseUrl: Boolean(STARTUP_ENV.DATABASE_URL) });
 
 const MEMORY_SYSTEM_ENABLED = process.env.MEMORY_SYSTEM_ENABLED === "1";
 const MEMORY_SYSTEM_ALLOWLIST = new Set(
@@ -736,7 +743,7 @@ const IS_DEV_MODE = STARTUP_ENV.IS_DEV_MODE;
 const IS_TEST_MODE = NODE_ENV === "test" || process.env.TEST_MODE === "1";
 
 console.log(
-  `[startup] env validated (mode=${NODE_ENV}, localDev=${LOCAL_DEV ? "yes" : "no"}, database=${STARTUP_ENV.DATABASE_URL ? "postgres+sqlite-fallback" : "sqlite"}, testMode=${IS_TEST_MODE ? "yes" : "no"})`
+  `[startup] env validated (mode=${NODE_ENV}, localDev=${LOCAL_DEV ? "yes" : "no"}, database=${STARTUP_DB_STRATEGY}, testMode=${IS_TEST_MODE ? "yes" : "no"})`
 );
 if (IS_TEST_MODE) {
   console.log(`[startup] test sqlite path: ${process.env.SQLITE_PATH || DB_FILE}`);
@@ -1228,7 +1235,8 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
     const winner = symbol === "X" ? "O" : "X";
     finalizeTicTacToeGame(room, game, { winner, reason: reason || "disconnect" });
   }
-const PG_ENABLED = Boolean(process.env.DATABASE_URL);
+const DB_STRATEGY = STARTUP_DB_STRATEGY;
+const PG_ENABLED = DB_STRATEGY === "postgres";
 const pgPool = PG_ENABLED
   ? new Pool({
       connectionString: process.env.DATABASE_URL,
@@ -1241,6 +1249,9 @@ if (!PG_ENABLED && IS_DEV_MODE) {
   console.warn("[db] PG unavailable, using SQLite dev fallback:", DB_FILE);
 }
 let DB_BACKEND = "sqlite";
+function shouldUsePostgresAsSourceOfTruth() {
+  return DB_STRATEGY === "postgres" && Boolean(pgPool) && PG_READY;
+}
 // ---- Postgres: helpers to keep legacy schemas compatible
 async function pgGetColumnType(tableName, columnName) {
   const { rows } = await pgPool.query(
@@ -2773,10 +2784,7 @@ const sessionMiddleware = session({
 });
 
 app.use(sessionMiddleware);
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", db: DB_BACKEND });
-});
+app.use(createHealthRoutes(() => DB_BACKEND));
 
 const genericRateLimitHandler = (_req, res) => {
   res.status(429).json({ message: "Too many requests, please try again later." });
@@ -15621,19 +15629,6 @@ async function toggleProfileLike(userId, targetUserId) {
         [userId, targetUserId, now]
       );
       const stats = await fetchProfileLikeStats(targetUserId, userId);
-      // Best-effort mirror to SQLite so legacy reads stay consistent.
-      try {
-        if (stats.liked) {
-          await dbRunAsync(
-            `INSERT OR IGNORE INTO profile_likes (user_id, target_user_id, created_at) VALUES (?, ?, ?)`,
-            [userId, targetUserId, now]
-          );
-        } else {
-          await dbRunAsync(`DELETE FROM profile_likes WHERE user_id = ? AND target_user_id = ?`, [userId, targetUserId]);
-        }
-      } catch (e) {
-        console.warn("[profile likes][sqlite mirror]", e?.message || e);
-      }
       return stats;
     } catch (e) {
       console.warn("[profile likes][pg toggle] failed, falling back to sqlite:", e?.message || e);
@@ -22305,13 +22300,7 @@ socket.on("disconnect", (reason) => {
 
 });
 
-app.use((err, req, res, _next) => {
-  logger.error("[http] unhandled error", { method: req.method, path: req.originalUrl, err });
-  if (res.headersSent) return;
-  const status = Number(err?.status || err?.statusCode) || 500;
-  const safeMessage = status >= 500 ? "Internal server error." : (err?.publicMessage || err?.message || "Request failed.");
-  res.status(status).json({ message: safeMessage, error: { message: safeMessage } });
-});
+app.use(errorHandler);
 
 // ---- Start
 const startupReady = Promise.allSettled([migrationsReady, pgInitPromise]);
@@ -22329,6 +22318,16 @@ async function startServer() {
     if (IS_PROD) {
       process.exit(1);
     }
+  }
+  try {
+    await validateStartupConnection({
+      strategy: DB_STRATEGY,
+      pgPool,
+      sqliteQuery: (sql) => dbAllAsync(sql, []),
+    });
+  } catch (err) {
+    console.error(`[startup] ${DB_STRATEGY} connection validation failed`, err);
+    process.exit(1);
   }
 
   console.log(`[startup] database backend selected: ${DB_BACKEND}`);

--- a/services/dbStrategy.js
+++ b/services/dbStrategy.js
@@ -1,0 +1,25 @@
+"use strict";
+
+function resolveDbStrategy({ hasDatabaseUrl }) {
+  return hasDatabaseUrl ? "postgres" : "sqlite";
+}
+
+async function validateStartupConnection({ strategy, pgPool, sqliteQuery }) {
+  if (strategy === "postgres") {
+    if (!pgPool) {
+      throw new Error("Postgres strategy selected but pgPool is not configured.");
+    }
+    await pgPool.query("SELECT 1");
+    return;
+  }
+
+  if (typeof sqliteQuery !== "function") {
+    throw new Error("SQLite strategy selected but sqliteQuery helper is missing.");
+  }
+  await sqliteQuery("SELECT 1");
+}
+
+module.exports = {
+  resolveDbStrategy,
+  validateStartupConnection,
+};

--- a/services/sqliteMigrationService.js
+++ b/services/sqliteMigrationService.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function execAsync(db, sql) {
+  return new Promise((resolve, reject) => {
+    db.exec(sql, (err) => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+async function applySqliteFileMigrations({ db, run, migrationsDir }) {
+  await run(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT UNIQUE NOT NULL,
+      applied_at INTEGER NOT NULL
+    )
+  `);
+
+  if (!fs.existsSync(migrationsDir)) {
+    return { applied: [] };
+  }
+
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+
+  const applied = [];
+  for (const file of files) {
+    const existing = await new Promise((resolve, reject) => {
+      db.get(
+        "SELECT filename FROM schema_migrations WHERE filename = ? LIMIT 1",
+        [file],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row || null);
+        }
+      );
+    });
+    if (existing) continue;
+
+    const fullPath = path.join(migrationsDir, file);
+    const sql = fs.readFileSync(fullPath, "utf8");
+    await execAsync(db, "BEGIN");
+    try {
+      await execAsync(db, sql);
+      await run(
+        "INSERT INTO schema_migrations (filename, applied_at) VALUES (?, ?)",
+        [file, Date.now()]
+      );
+      await execAsync(db, "COMMIT");
+      applied.push(file);
+    } catch (err) {
+      await execAsync(db, "ROLLBACK");
+      throw new Error(`Failed applying migration ${file}: ${err.message}`);
+    }
+  }
+
+  return { applied };
+}
+
+module.exports = {
+  applySqliteFileMigrations,
+};


### PR DESCRIPTION
### Motivation
- Consolidate database behavior so a single primary backend is chosen at startup (Postgres preferred) and validated to prevent silent startup failures or split-brain writes.
- Provide a reproducible migration path for SQLite so schema can be recreated from scratch reliably.
- Reduce drift risk from dual-write/mirror patterns by making writes target a single source of truth where safe.
- Start mechanical, low-risk modularization of the large `server.js` file to make future safe refactors easier.

### Description
- Centralized DB strategy selection and validation in `services/dbStrategy.js` and made startup use a single strategy (`postgres` when `DATABASE_URL` present, otherwise `sqlite`).
- Added `services/sqliteMigrationService.js` and wired it into `database.js` so `migrations/*.sql` files are applied once (uses a `schema_migrations` table and per-file transactions).
- Modified `database.js` to call the new SQLite file migration runner during migrations.
- Updated server startup to run explicit connection validation for the chosen backend via `validateStartupConnection` before the server continues.
- Removed a concrete SQLite mirror write for profile-like toggles and changed `setRoleEverywhere` to write only to the active source of truth (Postgres when ready, otherwise SQLite) to reduce dual-write drift.
- Began safe modularization by extracting the `/health` route to `routes/healthRoutes.js` and the global HTTP error handler to `middleware/errorHandler.js`, and wired both back into `server.js` (no behavioral change intended beyond centralization).

### Testing
- Ran `npm run check` (which runs `node --check` on key files) with no syntax errors.
- Ran `npm run test:validators` and all validation tests passed.
- The code changes were smoke-validated locally (lint/check + unit validator tests) and showed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec40437c6c833388eca4920ba71946)