### PR TITLE
Add server-authoritative multiplayer game framework with Bingo example

### DIFF
--- a/games/bingo/BingoGame.js
+++ b/games/bingo/BingoGame.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const Game = require("../core/Game");
+
+const MIN_NUMBER = 1;
+const MAX_NUMBER = 75;
+const CARD_SIZE = 15;
+
+function shuffle(arr) {
+  const next = [...arr];
+  for (let i = next.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [next[i], next[j]] = [next[j], next[i]];
+  }
+  return next;
+}
+
+class BingoGame extends Game {
+  init() {
+    const universe = Array.from({ length: MAX_NUMBER }, (_, idx) => idx + MIN_NUMBER);
+    this.state = {
+      numbersDrawn: [],
+      remainingNumbers: shuffle(universe),
+      cards: {},
+      marks: {},
+      winnerId: null,
+      lastActionAt: Date.now(),
+    };
+
+    for (const player of this.players) {
+      const card = shuffle(universe).slice(0, CARD_SIZE).sort((a, b) => a - b);
+      this.state.cards[player.id] = card;
+      this.state.marks[player.id] = [];
+    }
+
+    this.currentTurnIndex = 0;
+  }
+
+  handleAction(playerId, action = {}) {
+    const type = String(action?.type || "");
+    if (!type) throw new Error("Missing action type");
+
+    if (type === "draw-number") {
+      if (!this.validateTurn(playerId)) {
+        throw new Error("Not your turn");
+      }
+      const next = this.state.remainingNumbers.shift();
+      if (next == null) throw new Error("No numbers remaining");
+      this.state.numbersDrawn.push(next);
+      this.state.lastDrawnNumber = next;
+      this.state.lastActionAt = Date.now();
+      this.nextTurn();
+      return { type, number: next };
+    }
+
+    if (type === "mark-number") {
+      const number = Number(action?.number);
+      if (!Number.isInteger(number)) throw new Error("Invalid number");
+      if (!this.state.numbersDrawn.includes(number)) {
+        throw new Error("Number has not been drawn");
+      }
+      const card = this.state.cards[playerId] || [];
+      if (!card.includes(number)) {
+        throw new Error("Number is not on your card");
+      }
+      const marks = this.state.marks[playerId] || [];
+      if (marks.includes(number)) {
+        throw new Error("Number already marked");
+      }
+      marks.push(number);
+      this.state.marks[playerId] = marks;
+      this.state.lastActionAt = Date.now();
+      if (card.every((cardNumber) => marks.includes(cardNumber))) {
+        this.state.winnerId = playerId;
+      }
+      return { type, number };
+    }
+
+    throw new Error("Unsupported action type");
+  }
+
+  getVisibleState() {
+    return {
+      ...this.state,
+      currentTurnPlayerId: this.getCurrentTurnPlayerId(),
+    };
+  }
+
+  isFinished() {
+    return Boolean(this.state?.winnerId);
+  }
+
+  getWinner() {
+    return this.state?.winnerId || null;
+  }
+}
+
+module.exports = BingoGame;

--- a/games/card-match/CardMatchGame.js
+++ b/games/card-match/CardMatchGame.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const UnsupportedGame = require("../core/UnsupportedGame");
+
+class CardMatchGame extends UnsupportedGame {}
+
+module.exports = CardMatchGame;

--- a/games/core/Game.js
+++ b/games/core/Game.js
@@ -1,0 +1,54 @@
+"use strict";
+
+class Game {
+  constructor({ state = {}, players = [], currentTurnIndex = 0 } = {}) {
+    this.state = state || {};
+    this.players = Array.isArray(players) ? players : [];
+    this.currentTurnIndex = Number.isInteger(currentTurnIndex) ? currentTurnIndex : 0;
+  }
+
+  init() {
+    throw new Error("init() must be implemented by the game");
+  }
+
+  handleAction(_playerId, _action) {
+    throw new Error("handleAction(playerId, action) must be implemented by the game");
+  }
+
+  getVisibleState(_playerId) {
+    return this.state;
+  }
+
+  isFinished() {
+    return false;
+  }
+
+  getWinner() {
+    return null;
+  }
+
+  getCurrentTurnPlayerId() {
+    if (!Array.isArray(this.players) || this.players.length === 0) return null;
+    return this.players[this.currentTurnIndex]?.id ?? null;
+  }
+
+  nextTurn() {
+    if (!Array.isArray(this.players) || this.players.length === 0) return null;
+    this.currentTurnIndex = (this.currentTurnIndex + 1) % this.players.length;
+    return this.getCurrentTurnPlayerId();
+  }
+
+  validateTurn(playerId) {
+    const current = this.getCurrentTurnPlayerId();
+    return current != null && String(current) === String(playerId);
+  }
+
+  setPlayers(players = []) {
+    this.players = Array.isArray(players) ? players : [];
+    if (this.currentTurnIndex >= this.players.length) {
+      this.currentTurnIndex = 0;
+    }
+  }
+}
+
+module.exports = Game;

--- a/games/core/GameRegistry.js
+++ b/games/core/GameRegistry.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const BingoGame = require("../bingo/BingoGame");
+const CardMatchGame = require("../card-match/CardMatchGame");
+const MonsterGame = require("../monster-battle/MonsterGame");
+
+const GameRegistry = {
+  bingo: BingoGame,
+  "card-match": CardMatchGame,
+  "monster-battle": MonsterGame,
+};
+
+function getGameClass(gameType) {
+  const normalized = String(gameType || "").trim().toLowerCase();
+  return GameRegistry[normalized] || null;
+}
+
+module.exports = {
+  GameRegistry,
+  getGameClass,
+};

--- a/games/core/GameSessionService.js
+++ b/games/core/GameSessionService.js
@@ -1,0 +1,243 @@
+"use strict";
+
+const crypto = require("crypto");
+const { getGameClass } = require("./GameRegistry");
+
+function normalizeStatus(status) {
+  if (status === "lobby" || status === "active" || status === "finished") return status;
+  return "lobby";
+}
+
+class GameSessionService {
+  constructor({ dbAllAsync, dbRunAsync } = {}) {
+    this.dbAllAsync = dbAllAsync;
+    this.dbRunAsync = dbRunAsync;
+    this.sessionsById = new Map();
+    this.sessionIdByRoom = new Map();
+  }
+
+  instantiateGame({ gameType, state, players, currentTurnIndex }) {
+    const GameClass = getGameClass(gameType);
+    if (!GameClass) throw new Error(`Unsupported game type: ${gameType}`);
+    return new GameClass({ state, players, currentTurnIndex });
+  }
+
+  async loadPersistedSessions() {
+    const sessions = await this.dbAllAsync(
+      `SELECT id, room_id, game_type, state, status FROM game_sessions WHERE status IN ('lobby', 'active', 'finished')`
+    );
+
+    for (const row of sessions) {
+      const players = await this.dbAllAsync(
+        `SELECT user_id, username, connection_id, metadata
+         FROM game_players
+         WHERE session_id = ?
+         ORDER BY joined_at ASC`,
+        [row.id]
+      );
+
+      const parsedState = this.safeJson(row.state, {});
+      const normalizedPlayers = players.map((p) => ({
+        id: p.user_id,
+        username: p.username,
+        connectionId: p.connection_id || null,
+        metadata: this.safeJson(p.metadata, {}),
+      }));
+
+      const game = this.instantiateGame({
+        gameType: row.game_type,
+        state: parsedState,
+        players: normalizedPlayers,
+        currentTurnIndex: Number(parsedState?.currentTurnIndex || 0),
+      });
+
+      const session = {
+        id: row.id,
+        roomId: row.room_id,
+        gameType: row.game_type,
+        state: parsedState,
+        status: normalizeStatus(row.status),
+        players: normalizedPlayers,
+        game,
+      };
+
+      this.sessionsById.set(session.id, session);
+      this.sessionIdByRoom.set(session.roomId, session.id);
+    }
+  }
+
+  safeJson(value, fallback) {
+    try {
+      if (value == null || value === "") return fallback;
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  async createSession({ roomId, gameType, creator }) {
+    if (!roomId) throw new Error("Missing roomId");
+    if (!creator?.id) throw new Error("Unauthorized");
+    const existing = this.getSessionByRoom(roomId);
+    if (existing && existing.status !== "finished") {
+      throw new Error("Room already has an active game session");
+    }
+
+    const id = crypto.randomUUID();
+    const game = this.instantiateGame({ gameType, state: {}, players: [] });
+
+    const session = {
+      id,
+      roomId,
+      gameType,
+      state: {},
+      status: "lobby",
+      players: [],
+      game,
+    };
+
+    this.sessionsById.set(id, session);
+    this.sessionIdByRoom.set(roomId, id);
+
+    await this.dbRunAsync(
+      `INSERT INTO game_sessions (id, room_id, game_type, state, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'lobby', ?, ?)`,
+      [id, roomId, gameType, JSON.stringify({}), Date.now(), Date.now()]
+    );
+
+    await this.joinSession({ roomId, player: creator });
+    return this.getSessionById(id);
+  }
+
+  getSessionById(sessionId) {
+    return this.sessionsById.get(sessionId) || null;
+  }
+
+  getSessionByRoom(roomId) {
+    const sessionId = this.sessionIdByRoom.get(roomId);
+    if (!sessionId) return null;
+    return this.getSessionById(sessionId);
+  }
+
+  async joinSession({ roomId, player }) {
+    const session = this.getSessionByRoom(roomId);
+    if (!session) throw new Error("Game session not found");
+    if (session.status !== "lobby") throw new Error("Game already started");
+    if (!player?.id || !player?.username) throw new Error("Invalid player");
+
+    const existing = session.players.find((p) => String(p.id) === String(player.id));
+    if (existing) {
+      existing.connectionId = player.connectionId || existing.connectionId;
+      existing.metadata = player.metadata || existing.metadata || {};
+    } else {
+      session.players.push({
+        id: player.id,
+        username: player.username,
+        connectionId: player.connectionId || null,
+        metadata: player.metadata || {},
+      });
+    }
+
+    session.game.setPlayers(session.players);
+    await this.persistPlayers(session);
+    await this.persistSession(session);
+    return session;
+  }
+
+  async startSession({ roomId, playerId }) {
+    const session = this.getSessionByRoom(roomId);
+    if (!session) throw new Error("Game session not found");
+    if (session.status !== "lobby") throw new Error("Game already started");
+    const isInSession = session.players.some((p) => String(p.id) === String(playerId));
+    if (!isInSession) throw new Error("Only joined players can start");
+    if (session.players.length < 1) throw new Error("Need at least one player");
+
+    session.game.setPlayers(session.players);
+    session.game.init();
+    session.state = {
+      ...session.game.state,
+      currentTurnIndex: session.game.currentTurnIndex,
+    };
+    session.status = "active";
+
+    await this.persistSession(session);
+    return session;
+  }
+
+  async handleAction({ roomId, playerId, action }) {
+    const session = this.getSessionByRoom(roomId);
+    if (!session) throw new Error("Game session not found");
+    if (session.status !== "active") throw new Error("Game is not active");
+    const isInSession = session.players.some((p) => String(p.id) === String(playerId));
+    if (!isInSession) throw new Error("You are not a game player");
+
+    const result = session.game.handleAction(playerId, action);
+    session.state = {
+      ...session.game.state,
+      currentTurnIndex: session.game.currentTurnIndex,
+    };
+
+    if (session.game.isFinished()) {
+      session.status = "finished";
+    }
+
+    await this.persistSession(session);
+    return { session, result };
+  }
+
+  async reconnectPlayer({ roomId, playerId, connectionId }) {
+    const session = this.getSessionByRoom(roomId);
+    if (!session) return null;
+    const player = session.players.find((p) => String(p.id) === String(playerId));
+    if (!player) return session;
+    player.connectionId = connectionId;
+    await this.persistPlayers(session);
+    return session;
+  }
+
+  async persistPlayers(session) {
+    await this.dbRunAsync(`DELETE FROM game_players WHERE session_id = ?`, [session.id]);
+    for (const player of session.players) {
+      await this.dbRunAsync(
+        `INSERT INTO game_players (session_id, user_id, username, connection_id, metadata, joined_at)
+         VALUES (?, ?, ?, ?, ?, ?)` ,
+        [
+          session.id,
+          player.id,
+          player.username,
+          player.connectionId || null,
+          JSON.stringify(player.metadata || {}),
+          Date.now(),
+        ]
+      );
+    }
+  }
+
+  async persistSession(session) {
+    await this.dbRunAsync(
+      `UPDATE game_sessions
+       SET state = ?, status = ?, updated_at = ?
+       WHERE id = ?`,
+      [JSON.stringify(session.state || {}), session.status, Date.now(), session.id]
+    );
+  }
+
+  buildPayloadForPlayer(session, playerId) {
+    return {
+      sessionId: session.id,
+      roomId: session.roomId,
+      gameType: session.gameType,
+      status: session.status,
+      currentTurnIndex: session.game.currentTurnIndex,
+      players: session.players.map((p) => ({
+        id: p.id,
+        username: p.username,
+        connectionId: p.connectionId,
+        metadata: p.metadata || {},
+      })),
+      state: session.game.getVisibleState(playerId),
+    };
+  }
+}
+
+module.exports = GameSessionService;

--- a/games/core/UnsupportedGame.js
+++ b/games/core/UnsupportedGame.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const Game = require("./Game");
+
+class UnsupportedGame extends Game {
+  init() {
+    this.state = { message: "Game type not implemented yet" };
+  }
+
+  handleAction() {
+    throw new Error("This game type is not implemented yet");
+  }
+}
+
+module.exports = UnsupportedGame;

--- a/games/monster-battle/MonsterGame.js
+++ b/games/monster-battle/MonsterGame.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const UnsupportedGame = require("../core/UnsupportedGame");
+
+class MonsterGame extends UnsupportedGame {}
+
+module.exports = MonsterGame;

--- a/migrations/20260426_game_sessions.sql
+++ b/migrations/20260426_game_sessions.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS game_sessions (
+  id TEXT PRIMARY KEY,
+  room_id TEXT NOT NULL,
+  game_type TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL CHECK (status IN ('lobby', 'active', 'finished')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_game_sessions_room_id ON game_sessions(room_id);
+CREATE INDEX IF NOT EXISTS idx_game_sessions_status ON game_sessions(status);
+
+CREATE TABLE IF NOT EXISTS game_players (
+  session_id TEXT NOT NULL,
+  user_id INTEGER NOT NULL,
+  username TEXT NOT NULL,
+  connection_id TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  joined_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, user_id),
+  FOREIGN KEY (session_id) REFERENCES game_sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_game_players_session ON game_players(session_id);

--- a/server.js
+++ b/server.js
@@ -678,6 +678,7 @@ const dndCharacterSystem = require("./dnd/character-system");
 const dndEventTemplates = require("./dnd/event-templates");
 const dndEventResolution = require("./dnd/event-resolution");
 const dndDb = require("./dnd/database-helpers");
+const GameSessionService = require("./games/core/GameSessionService");
 
 // ---- Safety nets (prevents silent crashes in prod) ----
 process.on("unhandledRejection", (err) => {
@@ -18540,6 +18541,31 @@ function applyLuckForRoll({ luck, rollStreak, lastQualMsgAt, userId, now }) {
   return { nextLuck, nextStreak };
 }
 
+const gameSessionService = new GameSessionService({ dbAllAsync, dbRunAsync });
+
+function emitGameError(socket, message, details = {}) {
+  socket.emit("game:error", { message, ...details });
+}
+
+function broadcastGameUpdate(session) {
+  for (const player of session.players || []) {
+    if (!player?.connectionId) continue;
+    const payload = gameSessionService.buildPayloadForPlayer(session, player.id);
+    io.to(player.connectionId).emit("game:update", payload);
+  }
+}
+
+function broadcastGameEnd(session) {
+  const winnerId = session.game.getWinner?.() || null;
+  io.to(session.roomId).emit("game:end", {
+    sessionId: session.id,
+    roomId: session.roomId,
+    gameType: session.gameType,
+    winnerId,
+    state: session.game.getVisibleState(null),
+  });
+}
+
 // ---- Socket handlers
 io.on("connection", async (socket) => {
   const sessUser = socket.request.session?.user;
@@ -19953,6 +19979,97 @@ if (!room) {
         }
       );
     });
+  });
+
+  socket.on("game:create", async ({ roomId, gameType } = {}) => {
+    if (!socket.user) return emitGameError(socket, "Unauthorized");
+    const targetRoomId = String(roomId || socket.currentRoom || "").trim();
+    if (!targetRoomId) return emitGameError(socket, "Missing room");
+    if (!gameType) return emitGameError(socket, "Missing gameType");
+    try {
+      const session = await gameSessionService.createSession({
+        roomId: targetRoomId,
+        gameType: String(gameType),
+        creator: {
+          id: socket.user.id,
+          username: socket.user.username,
+          connectionId: socket.id,
+          metadata: {},
+        },
+      });
+      socket.join(targetRoomId);
+      broadcastGameUpdate(session);
+    } catch (err) {
+      emitGameError(socket, err?.message || "Failed to create game");
+    }
+  });
+
+  socket.on("game:join", async ({ roomId } = {}) => {
+    if (!socket.user) return emitGameError(socket, "Unauthorized");
+    const targetRoomId = String(roomId || socket.currentRoom || "").trim();
+    if (!targetRoomId) return emitGameError(socket, "Missing room");
+    try {
+      const session = await gameSessionService.joinSession({
+        roomId: targetRoomId,
+        player: {
+          id: socket.user.id,
+          username: socket.user.username,
+          connectionId: socket.id,
+          metadata: {},
+        },
+      });
+      socket.join(targetRoomId);
+      broadcastGameUpdate(session);
+    } catch (err) {
+      try {
+        const reconnectSession = await gameSessionService.reconnectPlayer({
+          roomId: targetRoomId,
+          playerId: socket.user.id,
+          connectionId: socket.id,
+        });
+        if (reconnectSession) {
+          const payload = gameSessionService.buildPayloadForPlayer(reconnectSession, socket.user.id);
+          socket.emit("game:update", payload);
+          return;
+        }
+      } catch (_ignored) {}
+      emitGameError(socket, err?.message || "Failed to join game");
+    }
+  });
+
+  socket.on("game:start", async ({ roomId } = {}) => {
+    if (!socket.user) return emitGameError(socket, "Unauthorized");
+    const targetRoomId = String(roomId || socket.currentRoom || "").trim();
+    if (!targetRoomId) return emitGameError(socket, "Missing room");
+    try {
+      const session = await gameSessionService.startSession({
+        roomId: targetRoomId,
+        playerId: socket.user.id,
+      });
+      broadcastGameUpdate(session);
+    } catch (err) {
+      emitGameError(socket, err?.message || "Failed to start game");
+    }
+  });
+
+  socket.on("game:action", async ({ roomId, action } = {}) => {
+    if (!socket.user) return emitGameError(socket, "Unauthorized");
+    const targetRoomId = String(roomId || socket.currentRoom || "").trim();
+    if (!targetRoomId) return emitGameError(socket, "Missing room");
+    if (!action || typeof action !== "object") return emitGameError(socket, "Invalid action");
+    try {
+      const { session } = await gameSessionService.handleAction({
+        roomId: targetRoomId,
+        playerId: socket.user.id,
+        action,
+      });
+      broadcastGameUpdate(session);
+      if (session.status === "finished") {
+        broadcastGameEnd(session);
+      }
+    } catch (err) {
+      emitGameError(socket, err?.message || "Failed to process action");
+    }
   });
 
 
@@ -22345,6 +22462,12 @@ async function startServer() {
     await ensureCoreRoomsExist();
   } catch (e) {
     console.warn("[startup] core room ensure failed", e?.message || e);
+  }
+
+  try {
+    await gameSessionService.loadPersistedSessions();
+  } catch (e) {
+    console.warn("[startup] game session restore failed", e?.message || e);
   }
 
   await ensureDevSeedUser();


### PR DESCRIPTION
### Motivation
- Provide a reusable, server-authoritative multiplayer game framework that integrates with the existing room/socket system and makes the server the single source of truth. 
- Support a full game lifecycle per room (`create → join → start → play → end`) with persistence and reconnect/resume across restarts. 
- Enable easy, plug-and-play addition of new games without embedding game-specific logic in socket handlers. 

### Description
- Introduce an abstract game base class `games/core/Game.js` that centralizes server-side state, turn management (`currentTurnIndex`, `nextTurn`, `validateTurn`) and the required game API (`init`, `handleAction`, `getVisibleState`, `isFinished`, `getWinner`).
- Add a `GameRegistry` at `games/core/GameRegistry.js` and a `GameSessionService` at `games/core/GameSessionService.js` that manage session lifecycle, instantiate games by `gameType`, persist sessions/players, reconnect players by `connectionId`, and expose `buildPayloadForPlayer(session, playerId)` for per-player filtered state.
- Implement a `BingoGame` at `games/bingo/BingoGame.js` that runs all logic server-side (number drawing, marking, win detection) and demonstrates broadcasting/turn handling with no hidden state for this example; add placeholder `CardMatchGame` and `MonsterGame` classes wired to the registry.
- Add SQLite migration `migrations/20260426_game_sessions.sql` with `game_sessions` and `game_players` tables and wire startup restore via `GameSessionService.loadPersistedSessions()` so games resume after server restart.
- Wire thin socket event handlers in `server.js` for client→server events `game:create`, `game:join`, `game:start`, `game:action` and server→client `game:update`, `game:error`, `game:end`, delegating validation and state mutation to `GameSessionService` and using `game.getVisibleState(playerId)` to filter per-player views.

### Testing
- Ran syntax checks: `node --check server.js`, `node --check games/core/Game.js`, `node --check games/core/GameSessionService.js`, `node --check games/bingo/BingoGame.js`, and `node --check games/core/GameRegistry.js` and they all passed. 
- Verified registry wiring with `node -e "const {GameRegistry}=require('./games/core/GameRegistry'); if(!GameRegistry.bingo) process.exit(1); console.log('ok');"` which printed `ok`.
- Basic smoke validation: server starts through startup checks in `server.js` and `GameSessionService` persisted-load path exercised during startup without fatal errors in the checks run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda49cdb4c83339503bdd817c35158)