### PR TITLE
Begin unified games migration: add Games modal, Tic Tac Toe & Chess adapters

### DIFF
--- a/games/chess/ChessGame.js
+++ b/games/chess/ChessGame.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const { Chess } = require("chess.js");
+const Game = require("../core/Game");
+
+class ChessGame extends Game {
+  constructor(options = {}) {
+    super(options);
+    const fen = options?.state?.fen || undefined;
+    this.chess = new Chess(fen);
+  }
+
+  init() {
+    this.currentTurnIndex = 0;
+    this.chess = new Chess();
+    this.state = {
+      fen: this.chess.fen(),
+      pgn: this.chess.pgn(),
+      turn: this.chess.turn(),
+      winner: null,
+      status: "active",
+      players: {
+        white: this.players?.[0]?.id || null,
+        black: this.players?.[1]?.id || null,
+      },
+      updatedAt: Date.now(),
+    };
+  }
+
+  handleAction(playerId, action = {}) {
+    const type = String(action?.type || "");
+    if (type !== "move") throw new Error("Unsupported action type");
+
+    const { white, black } = this.state.players || {};
+    const expectedPlayer = this.chess.turn() === "w" ? white : black;
+    if (!expectedPlayer || String(expectedPlayer) !== String(playerId)) {
+      throw new Error("Not your turn");
+    }
+
+    const from = String(action?.from || "").trim().toLowerCase();
+    const to = String(action?.to || "").trim().toLowerCase();
+    const promotion = String(action?.promotion || "").trim().toLowerCase() || undefined;
+    if (!from || !to) throw new Error("Invalid move");
+
+    const move = this.chess.move({ from, to, promotion });
+    if (!move) throw new Error("Illegal move");
+
+    this.state.fen = this.chess.fen();
+    this.state.pgn = this.chess.pgn();
+    this.state.turn = this.chess.turn();
+    this.state.updatedAt = Date.now();
+
+    if (this.chess.isCheckmate()) {
+      this.state.status = "mate";
+      this.state.winner = move.color === "w" ? "white" : "black";
+    } else if (this.chess.isStalemate() || this.chess.isDraw()) {
+      this.state.status = "draw";
+      this.state.winner = "draw";
+    }
+
+    this.currentTurnIndex = this.state.turn === "w" ? 0 : 1;
+    return { type, move };
+  }
+
+  getVisibleState() {
+    return {
+      ...this.state,
+      currentTurnPlayerId: this.getCurrentTurnPlayerId(),
+    };
+  }
+
+  isFinished() {
+    return this.state?.status === "mate" || this.state?.status === "draw";
+  }
+
+  getWinner() {
+    if (this.state?.winner === "white") return this.state?.players?.white || null;
+    if (this.state?.winner === "black") return this.state?.players?.black || null;
+    return null;
+  }
+}
+
+module.exports = ChessGame;

--- a/games/core/GameRegistry.js
+++ b/games/core/GameRegistry.js
@@ -3,11 +3,15 @@
 const BingoGame = require("../bingo/BingoGame");
 const CardMatchGame = require("../card-match/CardMatchGame");
 const MonsterGame = require("../monster-battle/MonsterGame");
+const TicTacToeGame = require("../tic-tac-toe/TicTacToeGame");
+const ChessGame = require("../chess/ChessGame");
 
 const GameRegistry = {
   bingo: BingoGame,
   "card-match": CardMatchGame,
   "monster-battle": MonsterGame,
+  "tic-tac-toe": TicTacToeGame,
+  chess: ChessGame,
 };
 
 function getGameClass(gameType) {

--- a/games/core/GameSessionService.js
+++ b/games/core/GameSessionService.js
@@ -150,7 +150,8 @@ class GameSessionService {
     if (session.status !== "lobby") throw new Error("Game already started");
     const isInSession = session.players.some((p) => String(p.id) === String(playerId));
     if (!isInSession) throw new Error("Only joined players can start");
-    if (session.players.length < 1) throw new Error("Need at least one player");
+    const minPlayers = session.gameType === "tic-tac-toe" || session.gameType === "chess" ? 2 : 1;
+    if (session.players.length < minPlayers) throw new Error(`Need at least ${minPlayers} players`);
 
     session.game.setPlayers(session.players);
     session.game.init();

--- a/games/tic-tac-toe/TicTacToeGame.js
+++ b/games/tic-tac-toe/TicTacToeGame.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const Game = require("../core/Game");
+
+const WIN_LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+function evaluateWinner(board = []) {
+  for (const line of WIN_LINES) {
+    const [a, b, c] = line;
+    const symbol = board[a];
+    if (!symbol) continue;
+    if (symbol === board[b] && symbol === board[c]) {
+      return { winner: symbol, line };
+    }
+  }
+  return { winner: null, line: null };
+}
+
+class TicTacToeGame extends Game {
+  init() {
+    this.currentTurnIndex = 0;
+    this.state = {
+      board: Array(9).fill(null),
+      symbolsByPlayerId: {
+        [this.players?.[0]?.id]: "X",
+        [this.players?.[1]?.id]: "O",
+      },
+      winner: null,
+      winningLine: null,
+      isDraw: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  handleAction(playerId, action = {}) {
+    const type = String(action?.type || "");
+    if (type !== "move") throw new Error("Unsupported action type");
+    if (!this.validateTurn(playerId)) throw new Error("Not your turn");
+
+    const index = Number(action?.index);
+    if (!Number.isInteger(index) || index < 0 || index > 8) throw new Error("Invalid move");
+    if (this.state.board[index]) throw new Error("Cell already occupied");
+
+    const symbol = this.state.symbolsByPlayerId?.[playerId];
+    if (!symbol) throw new Error("You are not a game player");
+
+    this.state.board[index] = symbol;
+    this.state.updatedAt = Date.now();
+
+    const { winner, line } = evaluateWinner(this.state.board);
+    if (winner) {
+      this.state.winner = winner;
+      this.state.winningLine = line;
+      this.state.isDraw = false;
+      return { type, index, symbol, winner };
+    }
+
+    if (this.state.board.every(Boolean)) {
+      this.state.winner = "draw";
+      this.state.isDraw = true;
+      return { type, index, symbol, winner: "draw" };
+    }
+
+    this.nextTurn();
+    return { type, index, symbol, winner: null };
+  }
+
+  getVisibleState() {
+    return {
+      ...this.state,
+      currentTurnPlayerId: this.getCurrentTurnPlayerId(),
+    };
+  }
+
+  isFinished() {
+    return Boolean(this.state?.winner);
+  }
+
+  getWinner() {
+    if (!this.state?.winner || this.state.winner === "draw") return null;
+    const winnerEntry = Object.entries(this.state.symbolsByPlayerId || {}).find(([, symbol]) => symbol === this.state.winner);
+    return winnerEntry?.[0] || null;
+  }
+}
+
+module.exports = TicTacToeGame;

--- a/public/app.js
+++ b/public/app.js
@@ -3041,6 +3041,16 @@ const chessState = {
   blackEloChange: null,
   seatClaimable: { white: false, black: false },
 };
+const unifiedGameState = {
+  sessionId: null,
+  roomId: null,
+  gameType: null,
+  status: null,
+  players: [],
+  state: null,
+  chessSelection: null,
+};
+
 const chessChallengesByThread = new Map();
 let pendingChessChallenge = null;
 const recentDiceRolls = new Map();
@@ -6781,7 +6791,15 @@ const leaderboardContainer = document.getElementById("leaderboardContainer");
 const leaderboardsMsg = document.getElementById("leaderboardsMsg");
 const leaderboardsUpdatedAt = document.getElementById("leaderboardsUpdatedAt");
 const refreshLeaderboardsBtn = document.getElementById("refreshLeaderboardsBtn");
-const roomChessBtn = document.getElementById("roomChessBtn");
+const gamesOpenBtn = document.getElementById("gamesOpenBtn");
+const gamesModal = document.getElementById("gamesModal");
+const gamesModalClose = document.getElementById("gamesModalClose");
+const gamesActiveSummary = document.getElementById("gamesActiveSummary");
+const gamesActiveActions = document.getElementById("gamesActiveActions");
+const roomGamePanel = document.getElementById("roomGamePanel");
+const roomGameTitle = document.getElementById("roomGameTitle");
+const roomGameStatus = document.getElementById("roomGameStatus");
+const roomGameBody = document.getElementById("roomGameBody");
 const dmChessBtn = document.getElementById("dmChessBtn");
 const dmChessChallenge = document.getElementById("dmChessChallenge");
 const chessModal = document.getElementById("chessModal");
@@ -10035,6 +10053,14 @@ function handleCommandResponse(payload){
     showCommandPopup("Command error", escapeHtml(payload?.message || "Adventure command failed."));
     return;
   }
+  if(payload?.type === "games") {
+    if (payload?.ok) {
+      openGamesModal();
+      return;
+    }
+    showCommandPopup("Command error", escapeHtml(payload?.message || "Games command failed."));
+    return;
+  }
   if(payload?.type === "help" && Array.isArray(payload.commands)){
     const roleLabel = payload.role || me?.role || "";
     const items = payload.commands.map(cmd=>{
@@ -10046,6 +10072,155 @@ function handleCommandResponse(payload){
   const msg = escapeHtml(payload?.message || "No response");
   const title = payload?.ok ? "Command" : "Command error";
   showCommandPopup(title, msg);
+}
+
+function openGamesModal() {
+  if (!gamesModal) return;
+  gamesModal.hidden = false;
+  renderGamesModal();
+}
+
+function closeGamesModal() {
+  if (!gamesModal) return;
+  gamesModal.hidden = true;
+}
+
+function updateUnifiedGameState(payload = null) {
+  if (!payload) {
+    unifiedGameState.sessionId = null;
+    unifiedGameState.roomId = null;
+    unifiedGameState.gameType = null;
+    unifiedGameState.status = null;
+    unifiedGameState.players = [];
+    unifiedGameState.state = null;
+    unifiedGameState.chessSelection = null;
+  } else {
+    unifiedGameState.sessionId = payload.sessionId || null;
+    unifiedGameState.roomId = payload.roomId || null;
+    unifiedGameState.gameType = payload.gameType || null;
+    unifiedGameState.status = payload.status || null;
+    unifiedGameState.players = Array.isArray(payload.players) ? payload.players : [];
+    unifiedGameState.state = payload.state || null;
+    if (unifiedGameState.gameType !== "chess") unifiedGameState.chessSelection = null;
+  }
+  renderGamesModal();
+  renderRoomGamePanel();
+}
+
+function renderGamesModal() {
+  if (!gamesActiveSummary || !gamesActiveActions) return;
+  if (!unifiedGameState.sessionId || unifiedGameState.roomId !== currentRoom) {
+    gamesActiveSummary.textContent = "No active game in this room.";
+    gamesActiveActions.innerHTML = "";
+    return;
+  }
+  const names = (unifiedGameState.players || []).map((p) => p.username).filter(Boolean).join(", ") || "None";
+  gamesActiveSummary.textContent = `${unifiedGameState.gameType} • ${unifiedGameState.status} • Players: ${names}`;
+  gamesActiveActions.innerHTML = "";
+  const joinBtn = document.createElement("button");
+  joinBtn.type = "button";
+  joinBtn.className = "btn secondary small";
+  joinBtn.textContent = unifiedGameState.status === "lobby" ? "Join" : "Resume";
+  joinBtn.addEventListener("click", () => {
+    socket?.emit("game:join", { roomId: currentRoom });
+  });
+  gamesActiveActions.appendChild(joinBtn);
+
+  if (unifiedGameState.status === "lobby") {
+    const startBtn = document.createElement("button");
+    startBtn.type = "button";
+    startBtn.className = "btn small";
+    startBtn.textContent = "Start";
+    startBtn.addEventListener("click", () => {
+      socket?.emit("game:start", { roomId: currentRoom });
+    });
+    gamesActiveActions.appendChild(startBtn);
+  }
+}
+
+function parseFenBoard(fen) {
+  const map = { p: "♟", r: "♜", n: "♞", b: "♝", q: "♛", k: "♚", P: "♙", R: "♖", N: "♘", B: "♗", Q: "♕", K: "♔" };
+  const boardFen = String(fen || "").split(" ")[0] || "";
+  const rows = boardFen.split("/");
+  const out = [];
+  for (const row of rows) {
+    for (const ch of row) {
+      if (/\d/.test(ch)) {
+        for (let i = 0; i < Number(ch); i += 1) out.push("");
+      } else {
+        out.push(map[ch] || "");
+      }
+    }
+  }
+  return out;
+}
+
+function renderRoomGamePanel() {
+  if (!roomGamePanel || !roomGameBody || !roomGameTitle || !roomGameStatus) return;
+  if (!unifiedGameState.sessionId || unifiedGameState.roomId !== currentRoom) {
+    roomGamePanel.hidden = true;
+    roomGameBody.innerHTML = "";
+    return;
+  }
+
+  roomGamePanel.hidden = false;
+  roomGameTitle.textContent = unifiedGameState.gameType === "tic-tac-toe" ? "Tic Tac Toe" : "Chess";
+  roomGameStatus.textContent = `${unifiedGameState.status || "lobby"}`;
+  roomGameBody.innerHTML = "";
+
+  const state = unifiedGameState.state || {};
+  if (unifiedGameState.gameType === "tic-tac-toe") {
+    const board = document.createElement("div");
+    board.className = "gameTttBoard";
+    const values = Array.isArray(state.board) ? state.board : Array(9).fill(null);
+    const currentTurnPlayerId = String(state.currentTurnPlayerId || "");
+    const myTurn = currentTurnPlayerId && String(me?.id || "") === currentTurnPlayerId && unifiedGameState.status === "active";
+    values.forEach((value, idx) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "btn secondary small gameTttCell";
+      btn.textContent = value || "";
+      btn.disabled = !!value || !myTurn;
+      btn.addEventListener("click", () => {
+        socket?.emit("game:action", { roomId: currentRoom, action: { type: "move", index: idx } });
+      });
+      board.appendChild(btn);
+    });
+    roomGameBody.appendChild(board);
+  }
+
+  if (unifiedGameState.gameType === "chess") {
+    const board = document.createElement("div");
+    board.className = "gameChessBoard";
+    const cells = parseFenBoard(state.fen);
+    for (let i = 0; i < 64; i += 1) {
+      const rank = 8 - Math.floor(i / 8);
+      const file = String.fromCharCode(97 + (i % 8));
+      const square = `${file}${rank}`;
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = `gameChessCell ${((Math.floor(i / 8) + (i % 8)) % 2 === 0) ? "light" : "dark"}`;
+      btn.textContent = cells[i] || "";
+      if (unifiedGameState.chessSelection === square) btn.classList.add("selected");
+      btn.addEventListener("click", () => {
+        if (unifiedGameState.status !== "active") return;
+        if (!unifiedGameState.chessSelection) {
+          unifiedGameState.chessSelection = square;
+          renderRoomGamePanel();
+          return;
+        }
+        const from = unifiedGameState.chessSelection;
+        unifiedGameState.chessSelection = null;
+        if (from === square) {
+          renderRoomGamePanel();
+          return;
+        }
+        socket?.emit("game:action", { roomId: currentRoom, action: { type: "move", from, to: square, promotion: "q" } });
+      });
+      board.appendChild(btn);
+    }
+    roomGameBody.appendChild(board);
+  }
 }
 
 function escapeRegex(str){
@@ -15541,8 +15716,21 @@ document.addEventListener("click", (e) => {
   closeProfileSettingsMenu();
 });
 
-roomChessBtn?.addEventListener("click", () => {
-  openChessModal({ contextType: "room", contextId: currentRoom, label: `Room • ${displayRoomName(currentRoom)}` });
+gamesOpenBtn?.addEventListener("click", () => {
+  openGamesModal();
+});
+
+gamesModalClose?.addEventListener("click", closeGamesModal);
+gamesModal?.addEventListener("click", (e) => {
+  if (e.target === gamesModal) closeGamesModal();
+});
+
+document.querySelectorAll("[data-game-start]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const gameType = btn.dataset.gameStart;
+    if (!gameType || !currentRoom) return;
+    socket?.emit("game:create", { roomId: currentRoom, gameType });
+  });
 });
 
 dmChessBtn?.addEventListener("click", () => {
@@ -17825,6 +18013,8 @@ function joinRoom(room){
   setActiveRoom(room);
   clearMsgs();
   socket?.emit("join room", { room, status: normalizeStatusLabel(statusSelect.value, "Online") });
+  socket?.emit("game:join", { roomId: room });
+  if (unifiedGameState.roomId && unifiedGameState.roomId !== room) renderRoomGamePanel();
   closeDrawers();
   
   // Update presence when changing rooms
@@ -20944,6 +21134,12 @@ dmText?.addEventListener("input", () => {
 
 async function sendMessage(){
   const text = msgInput.value || "";
+  const trimmed = String(text || "").trim();
+  if (/^\/(game|games)(\s|$)/i.test(trimmed)) {
+    msgInput.value = "";
+    openGamesModal();
+    return;
+  }
   const file = pendingFile;
   const attachmentReady = roomPendingAttachment;
   if(roomUploading && !attachmentReady) return;
@@ -26761,6 +26957,21 @@ initAppealsDurationSelect();
     try{
       if(typeof playSound === "function") playSound("mention");
     }catch(_){}
+  });
+
+  socket.on("game:update", (payload = {}) => {
+    if (!payload || payload.roomId !== currentRoom) return;
+    updateUnifiedGameState(payload);
+  });
+
+  socket.on("game:error", (payload = {}) => {
+    const message = payload?.message || "Game error";
+    showToast(`🎮 ${message}`, { durationMs: 2600 });
+  });
+
+  socket.on("game:end", (payload = {}) => {
+    if (payload?.roomId !== currentRoom) return;
+    showToast("🎮 Game ended", { durationMs: 2600 });
   });
 
   socket.on("survival:update", (payload = {}) => {

--- a/public/index.html
+++ b/public/index.html
@@ -339,7 +339,7 @@
 <button class="iconBtn withBadge" id="dmToggleBtn" title="Direct messages" type="button">💬<span class="notifDot" id="dmBadgeDot" title="New DMs"></span></button>
 <button class="iconBtn withBadge" id="groupDmToggleBtn" title="Group DMs" type="button">👥<span class="notifDot" id="groupDmBadgeDot" title="New group DMs"></span></button>
 <button aria-label="Notifications" class="iconBtn withBadge" id="notificationsBtn" title="Notifications" type="button">🔔<span class="notifDot" id="notificationsDot" title="New notifications"></span></button>
-<button class="iconBtn" id="roomChessBtn" title="Chess Table" type="button">♟</button>
+<button aria-label="Open Games" class="btn secondary small" id="gamesOpenBtn" title="Games" type="button">🎮 Games</button>
 <button aria-label="Open Simulator" class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" title="Open Simulator" type="button">🧭</button>
 <button aria-label="Open DnD" class="btn secondary small dndOpenBtn" hidden id="dndOpenBtn" title="Open DnD" type="button">🎲 <span class="dndOpenLabel">DnD</span></button>
 <button class="iconBtn mobOnly" id="openMembersBtn" title="Members" type="button">👥</button>
@@ -416,6 +416,29 @@
 </div>
 </div>
 </div>
+<div class="modal" hidden="" id="gamesModal">
+  <div class="modalCard gamesModalCard">
+    <div class="modalTop">
+      <strong>Games</strong>
+      <button aria-label="Close" class="iconBtn" id="gamesModalClose" type="button">✕</button>
+    </div>
+    <div class="modalBody">
+      <section class="gamesModalSection">
+        <h4>Start a Game</h4>
+        <div class="gamesStartList">
+          <div class="gamesStartItem"><span>Tic Tac Toe</span><button class="btn secondary small" data-game-start="tic-tac-toe" type="button">Start</button></div>
+          <div class="gamesStartItem"><span>Chess</span><button class="btn secondary small" data-game-start="chess" type="button">Start</button></div>
+        </div>
+      </section>
+      <section class="gamesModalSection">
+        <h4>Active Game</h4>
+        <div class="small muted" id="gamesActiveSummary">No active game in this room.</div>
+        <div class="gamesActiveActions" id="gamesActiveActions"></div>
+      </section>
+    </div>
+  </div>
+</div>
+
 <div class="modal" hidden="" id="survivalModal">
 <div class="modalCard survivalModal survivalModalShell">
 <div class="modalTop survivalModalTop">
@@ -674,6 +697,13 @@
 </div>
 <div class="msgs" id="msgs"></div>
 <div class="typing" id="typing"></div>
+<div class="gamePanel" hidden id="roomGamePanel">
+  <div class="gamePanelHeader">
+    <strong id="roomGameTitle">Game</strong>
+    <span class="small muted" id="roomGameStatus">No active game</span>
+  </div>
+  <div class="gamePanelBody" id="roomGameBody"></div>
+</div>
 <div class="uploadPreview" id="uploadPreview">
 <div class="uploadLeft">
 <div class="previewThumb" id="previewThumb"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -16793,3 +16793,20 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
 }
 
 /* ========== END PRESENCE SYSTEM STYLES ========== */
+
+/* Unified games UI */
+.gamesModalCard { width:min(560px,92vw); }
+.gamesModalSection { margin-bottom:14px; }
+.gamesStartList { display:flex; flex-direction:column; gap:8px; }
+.gamesStartItem { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 10px; border:1px solid var(--line); border-radius:10px; }
+.gamesActiveActions { display:flex; gap:8px; margin-top:10px; }
+
+.gamePanel { margin:10px 12px 0; border:1px solid var(--line); border-radius:12px; padding:10px; background:var(--surface2, rgba(255,255,255,0.03)); }
+.gamePanelHeader { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; gap:8px; }
+.gameTttBoard { display:grid; grid-template-columns:repeat(3,46px); gap:6px; }
+.gameTttCell { width:46px; height:46px; font-weight:700; }
+.gameChessBoard { display:grid; grid-template-columns:repeat(8,36px); border:1px solid var(--line); width:max-content; }
+.gameChessCell { width:36px; height:36px; border:0; font-size:22px; cursor:pointer; }
+.gameChessCell.light { background:#f0d9b5; }
+.gameChessCell.dark { background:#b58863; }
+.gameChessCell.selected { outline:2px solid #43b581; }

--- a/server.js
+++ b/server.js
@@ -5630,6 +5630,20 @@ const commandRegistry = {
       return { ok: true, type: "dnd", message: "Opening DnD..." };
     },
   },
+  game: {
+    minRole: "User",
+    description: "Open the Games menu",
+    usage: "/game",
+    example: "/game",
+    handler: async () => ({ ok: true, type: "games", message: "Opening Games..." }),
+  },
+  games: {
+    minRole: "User",
+    description: "Open the Games menu",
+    usage: "/games",
+    example: "/games",
+    handler: async () => ({ ok: true, type: "games", message: "Opening Games..." }),
+  },
   ttt: {
     minRole: "User",
     description: "Start or manage a Tic Tac Toe game in this room",
@@ -18548,11 +18562,7 @@ function emitGameError(socket, message, details = {}) {
 }
 
 function broadcastGameUpdate(session) {
-  for (const player of session.players || []) {
-    if (!player?.connectionId) continue;
-    const payload = gameSessionService.buildPayloadForPlayer(session, player.id);
-    io.to(player.connectionId).emit("game:update", payload);
-  }
+  io.to(session.roomId).emit("game:update", gameSessionService.buildPayloadForPlayer(session, null));
 }
 
 function broadcastGameEnd(session) {
@@ -20028,11 +20038,15 @@ if (!room) {
           connectionId: socket.id,
         });
         if (reconnectSession) {
-          const payload = gameSessionService.buildPayloadForPlayer(reconnectSession, socket.user.id);
-          socket.emit("game:update", payload);
+          socket.emit("game:update", gameSessionService.buildPayloadForPlayer(reconnectSession, socket.user.id));
           return;
         }
       } catch (_ignored) {}
+      const existingSession = gameSessionService.getSessionByRoom(targetRoomId);
+      if (existingSession) {
+        socket.emit("game:update", gameSessionService.buildPayloadForPlayer(existingSession, socket.user.id));
+        return;
+      }
       emitGameError(socket, err?.message || "Failed to join game");
     }
   });


### PR DESCRIPTION
### Motivation
- Provide a unified multiplayer games entry point and migrate the simplest games into the new `Game` framework to enable room-scoped, session-driven play. 
- Keep existing game logic intact (adapter pattern) and avoid touching dice functionality or unrelated chat features. 

### Description
- Added `TicTacToeGame` and `ChessGame` adapters implementing the `Game` interface with `init`, `handleAction`, `getVisibleState`, and finish detection, reusing existing move/win logic where applicable. 
- Registered new game classes in `GameRegistry` under `tic-tac-toe` and `chess`. 
- Updated `GameSessionService.startSession` to enforce a minimum of two players for Tic Tac Toe and Chess and to initialize the game via the adapter. 
- Server socket flow: kept thin handlers for `game:create`, `game:join`, `game:start`, and `game:action`, changed `broadcastGameUpdate` to emit room-scoped `game:update`, and improved `game:join` fallback to send current session state to connecting sockets. 
- Frontend: added a single top-bar `🎮 Games` button, a `Games` modal (start list + active game summary), a minimal in-room `gamePanel` for active sessions (3x3 Tic Tac Toe grid and basic chess board UI), and client handlers for `game:update`, `game:error`, and `game:end`. 
- Slash command support: added `/game` and `/games` backend commands and wired the client to open the `Games` modal instead of sending a chat message. 
- UI styling: lightweight CSS for modal, in-room panel, Tic Tac Toe grid, and chess board; dice-related UI/logic left unchanged. 

### Testing
- Performed static checks with `node --check` across modified backend and frontend files and no syntax errors were reported. 
- Ran the repository validation script `npm run check` and it completed successfully. 
- Manual smoke validation in code: wired socket event handlers and client render paths for `game:update`/`game:error`/`game:end` and ensured the client opens the `Games` modal on `/game` or `/games` input (no visual screenshot run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda75d542883338a9c39b4eeab7015)