### PR TITLE
Harden game init flow: stop missing gameId toasts and duplicate initialization

### DIFF
--- a/games/core/GameManager.js
+++ b/games/core/GameManager.js
@@ -40,6 +40,10 @@ class GameManager {
   }
 
   async joinGame({ gameId, userId }) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      return null;
+    }
     const session = this.requireGame(gameId);
     if (!userId) throw new Error("Missing userId");
 
@@ -61,6 +65,10 @@ class GameManager {
   }
 
   async leaveGame({ gameId, userId }) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      return null;
+    }
     const session = this.requireGame(gameId);
     const nextPlayers = session.players.filter((p) => String(p.id) !== String(userId));
     if (nextPlayers.length === session.players.length) return this.buildMetadata(session);
@@ -80,6 +88,10 @@ class GameManager {
   }
 
   async endGame({ gameId, reason = "completed" }) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      return null;
+    }
     const session = this.requireGame(gameId);
     session.status = "finished";
     session.endedAt = Date.now();
@@ -98,6 +110,7 @@ class GameManager {
   }
 
   getGame(gameId) {
+    if (!this.isValidGameId(gameId)) return null;
     return this.games.get(gameId) || null;
   }
 
@@ -106,6 +119,13 @@ class GameManager {
   }
 
   emitGameState(gameId) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      return null;
+    }
+    if (process.env.NODE_ENV !== "production") {
+      console.log("Game init attempt:", { gameId });
+    }
     const session = this.requireGame(gameId);
     const state = {
       gameId,
@@ -120,6 +140,10 @@ class GameManager {
   }
 
   async handleAction({ gameId, userId, action, payload }) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      return null;
+    }
     const session = this.requireGame(gameId);
     if (session.status === "finished") throw new Error("Game already finished");
     if (!session.players.some((p) => String(p.id) === String(userId))) {
@@ -139,6 +163,10 @@ class GameManager {
   }
 
   requireGame(gameId) {
+    if (!this.isValidGameId(gameId)) {
+      console.warn("GameManager called without gameId");
+      throw new Error("Game not found");
+    }
     const session = this.getGame(gameId);
     if (!session) throw new Error("Game not found");
     return session;
@@ -169,6 +197,10 @@ class GameManager {
          updated_at = excluded.updated_at`,
       [session.id, `game:${session.id}`, session.gameType, JSON.stringify(session.state || {}), session.status, session.startedAt || now, now]
     );
+  }
+
+  isValidGameId(gameId) {
+    return typeof gameId === "string" && gameId.length > 0;
   }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -3056,6 +3056,10 @@ let currentGameId = null;
 window.activeGames = activeGames;
 window.currentGameId = currentGameId;
 
+function isValidGameId(gameId) {
+  return typeof gameId === "string" && gameId.trim().length > 0;
+}
+
 const chessChallengesByThread = new Map();
 let pendingChessChallenge = null;
 const recentDiceRolls = new Map();
@@ -10124,7 +10128,10 @@ function renderGamesModal() {
   joinBtn.className = "btn secondary small";
   joinBtn.textContent = unifiedGameState.status === "lobby" ? "Join" : "Resume";
   joinBtn.addEventListener("click", () => {
-    socket?.emit("game:join", { roomId: currentRoom });
+    const gameId = String(unifiedGameState.sessionId || "").trim();
+    if (!isValidGameId(gameId)) return;
+    window.currentGameId = gameId;
+    socket?.emit("game:join", { gameId });
   });
   gamesActiveActions.appendChild(joinBtn);
 
@@ -10134,7 +10141,9 @@ function renderGamesModal() {
     startBtn.className = "btn small";
     startBtn.textContent = "Start";
     startBtn.addEventListener("click", () => {
-      socket?.emit("game:start", { roomId: currentRoom });
+      const gameId = String(unifiedGameState.sessionId || "").trim();
+      if (!isValidGameId(gameId)) return;
+      socket?.emit("game:start", { gameId });
     });
     gamesActiveActions.appendChild(startBtn);
   }
@@ -10184,7 +10193,9 @@ function renderRoomGamePanel() {
       btn.textContent = value || "";
       btn.disabled = !!value || !myTurn;
       btn.addEventListener("click", () => {
-        socket?.emit("game:action", { roomId: currentRoom, action: { type: "move", index: idx } });
+        const gameId = String(unifiedGameState.sessionId || "").trim();
+        if (!isValidGameId(gameId)) return;
+        socket?.emit("game:action", { gameId, action: "move", payload: { index: idx } });
       });
       board.appendChild(btn);
     });
@@ -10217,7 +10228,9 @@ function renderRoomGamePanel() {
           renderRoomGamePanel();
           return;
         }
-        socket?.emit("game:action", { roomId: currentRoom, action: { type: "move", from, to: square, promotion: "q" } });
+        const gameId = String(unifiedGameState.sessionId || "").trim();
+        if (!isValidGameId(gameId)) return;
+        socket?.emit("game:action", { gameId, action: "move", payload: { from, to: square, promotion: "q" } });
       });
       board.appendChild(btn);
     }
@@ -18008,7 +18021,6 @@ function joinRoom(room){
   setActiveRoom(room);
   clearMsgs();
   socket?.emit("join room", { room, status: normalizeStatusLabel(statusSelect.value, "Online") });
-  socket?.emit("game:join", { roomId: room });
   if (unifiedGameState.roomId && unifiedGameState.roomId !== room) renderRoomGamePanel();
   closeDrawers();
   

--- a/public/games/gameRenderer.js
+++ b/public/games/gameRenderer.js
@@ -8,7 +8,7 @@
   }
 
   function emitAction(socket, gameId, action, payload = {}) {
-    if (!socket || !gameId || !action) return;
+    if (!socket || typeof gameId !== "string" || gameId.length === 0 || !action) return;
     socket.emit("game:action", { gameId, action, payload });
   }
 

--- a/public/games/gameSession.js
+++ b/public/games/gameSession.js
@@ -29,7 +29,10 @@
 
   function open({ socket, gameId, gameType }) {
     socketRef = socketRef || socket;
-    if (!socketRef || !gameId) return;
+    if (!socketRef || typeof gameId !== "string" || gameId.length === 0) return;
+    if (typeof process !== "undefined" && process?.env?.NODE_ENV !== "production") {
+      console.log("Game init attempt:", { gameId });
+    }
     window.currentGameId = gameId;
     const overlay = ensureOverlay();
     overlay.hidden = false;
@@ -67,7 +70,9 @@
   }
 
   function leave() {
-    if (socketRef && window.currentGameId) socketRef.emit("game:leave", { gameId: window.currentGameId });
+    if (socketRef && typeof window.currentGameId === "string" && window.currentGameId.length > 0) {
+      socketRef.emit("game:leave", { gameId: window.currentGameId });
+    }
     window.currentGameId = null;
     close();
   }

--- a/server.js
+++ b/server.js
@@ -20030,7 +20030,10 @@ if (!room) {
 
   socket.on("game:join", async ({ gameId } = {}) => {
     if (!socket.user) return emitGameError(socket, "Unauthorized");
-    if (!gameId) return emitGameError(socket, "Missing gameId");
+    if (typeof gameId !== "string" || gameId.length === 0) {
+      console.warn("game:join called without valid gameId");
+      return;
+    }
 
     try {
       socket.join(`game:${gameId}`);
@@ -20042,7 +20045,10 @@ if (!room) {
 
   socket.on("game:leave", async ({ gameId } = {}) => {
     if (!socket.user) return emitGameError(socket, "Unauthorized");
-    if (!gameId) return emitGameError(socket, "Missing gameId");
+    if (typeof gameId !== "string" || gameId.length === 0) {
+      console.warn("game:leave called without valid gameId");
+      return;
+    }
 
     try {
       socket.leave(`game:${gameId}`);
@@ -20054,7 +20060,10 @@ if (!room) {
 
   socket.on("game:action", async ({ gameId, action, payload } = {}) => {
     if (!socket.user) return emitGameError(socket, "Unauthorized");
-    if (!gameId) return emitGameError(socket, "Missing gameId");
+    if (typeof gameId !== "string" || gameId.length === 0) {
+      console.warn("game:action called without valid gameId");
+      return;
+    }
     if (!action) return emitGameError(socket, "Missing action");
 
     try {


### PR DESCRIPTION
### Motivation
- Prevent GameManager and socket handlers from being invoked with invalid or empty `gameId` values that caused user-facing "missing gameId" toasts on load.
- Eliminate duplicate/accidental game initialization that occurred during page/room startup and UI rehydration.
- Add defensive checks and developer-only logging to make the game lifecycle predictable and reduce noise.

### Description
- Fixed client UI emits to send `gameId` (using `unifiedGameState.sessionId`) and added `isValidGameId` checks to avoid emitting when empty; updated `public/app.js` to change `game:join`, `game:start`, and `game:action` call sites to use validated `gameId` and payload shape. (addresses `renderGamesModal`, room panel action buttons, and start/join flows).
- Removed the automatic `socket.emit("game:join", { roomId })` call from `joinRoom` in `public/app.js` to avoid unintended auto-joins during room changes/initialization.
- Hardened client-side helpers: added strict guards and dev-only logging in `public/games/gameSession.js` and stricter validation in `public/games/gameRenderer.js` to prevent emitting game events with invalid IDs.
- Hardened server socket handlers in `server.js` for `game:join`, `game:leave`, and `game:action` to ignore invalid `gameId` values and `console.warn` instead of returning `game:error` to clients.
- Added defensive validation and logging inside `games/core/GameManager.js` for all entry points (`joinGame`, `leaveGame`, `endGame`, `emitGameState`, `handleAction`, `requireGame`, `getGame`) and a helper `isValidGameId` to ensure the manager never processes empty IDs and logs developer-friendly warnings.
- Locations where invalid `gameId` was being passed or emitted: `public/app.js` (automatic `game:join` on room join and room UI buttons emitting `{ roomId }`), `public/app.js` room-panel action handlers (TTT/chess emitted `{ roomId, action }`), `public/games/gameSession.js` (open/leave flows could emit without strict validation). These were the key sources of the duplicate toasts.
- Why it happened twice: one invalid emit came from the automatic `joinRoom` `game:join` call during room initialization and the other came from game UI code emitting with the wrong payload shape (`roomId` instead of `gameId`) as the UI rehydrated; both produced server `game:error` responses that created two toasts.
- Behavior change: invalid/empty `gameId` calls are now no-ops with console warnings on both client and server, and GameManager defends itself against bad inputs.

### Testing
- Ran `npm run -s check` (project syntax/type checks) and it completed successfully.
- Verified via static inspection that all emit sites found in the audit (`public/app.js`, `public/games/*`, `server.js`) now perform `gameId` validation before emitting or handling events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e4fc61ac8333ae3db657c98a71d8)