### PR TITLE
Fix Games menu recursion, stabilize initChatApp, and harden DOM/dice FX calls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10084,7 +10084,10 @@ function handleCommandResponse(payload){
 }
 
 function openGamesMenu() {
-  window.openGamesMenu?.();
+  const openMenu = window.openGamesMenu;
+  if (typeof openMenu !== "function" || openMenu === openGamesMenu) return;
+  console.log("Opening games menu");
+  openMenu();
 }
 
 function closeGamesMenu() {
@@ -13641,16 +13644,18 @@ async function loadProgression(){
 
 // Search filter
 function applySearch(){
+  if (!searchInput) return;
   const q = searchInput.value.trim().toLowerCase();
   if(!q){
-    msgIndex.forEach(m => m.el.style.display = "");
+    msgIndex.forEach(m => { if (m?.el) m.el.style.display = ""; });
     return;
   }
   msgIndex.forEach(m => {
+    if (!m?.el) return;
     m.el.style.display = m.textLower.includes(q) ? "" : "none";
   });
 }
-searchInput.addEventListener("input", applySearch);
+searchInput?.addEventListener("input", applySearch);
 
 // drawers
 function anyDrawerOpen(){
@@ -26612,7 +26617,15 @@ function urlBase64ToUint8Array(base64String) {
 // ========== END PRESENCE SYSTEM FUNCTIONS ==========
 
 // start app
+let appInitialized = false;
+let initChatAppPromise = null;
+let mountDiceFx = () => {};
+let unmountDiceFx = () => {};
+
 async function initChatApp(){
+  if (appInitialized) return;
+  if (initChatAppPromise) return initChatAppPromise;
+  initChatAppPromise = (async () => {
   const sessionUser = await validateSession();
   if(!sessionUser){
     initLoginUI();
@@ -27427,7 +27440,7 @@ socket.on("mod:case_event", (payload = {}) => {
   confettiLayer.style.display = "none";
 
   let diceFxMounted = false;
-  function mountDiceFx(){
+  mountDiceFx = function mountDiceFx(){
     if (diceFxMounted) return;
     const chatMain = document.querySelector("main.chat") || document.getElementById("chatMain") || document.body;
     chatMain.style.position = chatMain.style.position || "relative";
@@ -27435,7 +27448,7 @@ socket.on("mod:case_event", (payload = {}) => {
     if (!chatMain.contains(confettiLayer)) chatMain.appendChild(confettiLayer);
     diceFxMounted = true;
   }
-  function unmountDiceFx(){
+  unmountDiceFx = function unmountDiceFx(){
     if (!diceFxMounted) return;
     diceOverlay.style.display = "none";
     confettiLayer.style.display = "none";
@@ -28143,7 +28156,14 @@ socket.on("dm history", (payload = {}) => {
   // Mark chat as initialized and flush any buffered messages
   isInitialized = true;
   flushIncomingMessageBuffer();
+  appInitialized = true;
+})();
 
+try {
+  await initChatAppPromise;
+} finally {
+  initChatAppPromise = null;
+}
 }
 
 // boot: auth gate


### PR DESCRIPTION
### Motivation
- Prevent infinite recursion when opening the Games UI caused by wrapper delegation to a global that could alias back to the wrapper. 
- Stop runtime crashes from undefined legacy functions and missing DOM nodes and ensure the app initializes exactly once to avoid duplicate socket/listener binding.

### Description
- Replaced `openGamesMenu` with a guarded delegator that avoids self-alias recursion and emits a single log: `function openGamesMenu() { const openMenu = window.openGamesMenu; if (typeof openMenu !== "function" || openMenu === openGamesMenu) return; console.log("Opening games menu"); openMenu(); }`.
- Added single-run init guards `let appInitialized = false` and `let initChatAppPromise = null` around `initChatApp()` so concurrent/duplicate calls return early and in-flight initialization is awaited.
- Introduced safe no-op globals `let mountDiceFx = () => {}; let unmountDiceFx = () => {};` and converted the in-init `mountDiceFx`/`unmountDiceFx` declarations to assignments so room transitions can safely call them before full init.
- Hardened `applySearch()` by guarding `searchInput` and `m.el` access and made the listener optional with `searchInput?.addEventListener("input", applySearch);` to avoid early-DOM crashes.

### Testing
- Ran a JavaScript syntax check with `node --check /workspace/BnB/public/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e732933083339b9676966532022a)