### PR TITLE
Mobile-first chat UI overhaul and Games button fallback

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10085,9 +10085,16 @@ function handleCommandResponse(payload){
 
 function openGamesMenu() {
   const openMenu = window.openGamesMenu;
-  if (typeof openMenu !== "function" || openMenu === openGamesMenu) return;
-  console.log("Opening games menu");
-  openMenu();
+  if (typeof openMenu === "function" && openMenu !== openGamesMenu) {
+    console.log("Opening games menu");
+    openMenu();
+    return;
+  }
+  if (gamesModal) {
+    gamesModal.hidden = false;
+    gamesModal.classList.add("modal-visible");
+    document.body.classList.add("modal-open");
+  }
 }
 
 function closeGamesMenu() {

--- a/public/index.html
+++ b/public/index.html
@@ -339,7 +339,7 @@
 <button class="iconBtn withBadge" id="dmToggleBtn" title="Direct messages" type="button">💬<span class="notifDot" id="dmBadgeDot" title="New DMs"></span></button>
 <button class="iconBtn withBadge" id="groupDmToggleBtn" title="Group DMs" type="button">👥<span class="notifDot" id="groupDmBadgeDot" title="New group DMs"></span></button>
 <button aria-label="Notifications" class="iconBtn withBadge" id="notificationsBtn" title="Notifications" type="button">🔔<span class="notifDot" id="notificationsDot" title="New notifications"></span></button>
-<button aria-label="Open Games" class="btn secondary small" id="gamesOpenBtn" title="Games" type="button">🎮 Games</button>
+<button aria-label="Open Games" class="btn secondary small" id="gamesOpenBtn" title="Games" type="button">🎮</button>
 <button aria-label="Open Simulator" class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" title="Open Simulator" type="button">🧭</button>
 <button aria-label="Open DnD" class="btn secondary small dndOpenBtn" hidden id="dndOpenBtn" title="Open DnD" type="button">🎲 <span class="dndOpenLabel">DnD</span></button>
 <button class="iconBtn mobOnly" id="openMembersBtn" title="Members" type="button">👥</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -16816,3 +16816,54 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
 .gameChessCell.light { background:#f0d9b5; }
 .gameChessCell.dark { background:#b58863; }
 .gameChessCell.selected { outline:2px solid #43b581; }
+
+
+/* === Mobile-first UI/UX cleanup (chat core) === */
+:root{ --space-1:8px; --space-2:12px; --space-3:16px; }
+
+.chat-main .msgs,
+.msg,
+.bubble,
+.topbar,
+.topActions,
+.inputBar,
+.modalCard,
+.modalBody,
+.roomTitle,
+.searchWrap,
+.tonePicker,
+.toneMenuPanel,
+.gamesModalCard{ max-width:100%; min-width:0; }
+
+@media (max-width: 768px){
+  .topbar{ height:48px; min-height:48px; flex-basis:48px; padding:0 var(--space-2); gap:var(--space-1); }
+  .topbar .topLeft{ flex:1 1 auto; min-width:0; }
+  .topbar .roomTitle{ min-width:0; font-size:14px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .topbar .topActions{ gap:var(--space-1); }
+  .topbar .btn.secondary.small,
+  .topbar .iconBtn{ width:40px; min-width:40px; height:40px; padding:0; display:inline-flex; align-items:center; justify-content:center; }
+  .topbar #gamesOpenBtn{ font-size:18px; }
+
+  .chat-main .msgs{ padding:var(--space-2); gap:var(--space-1); overflow-x:hidden; }
+  .msg{ gap:var(--space-1); }
+  .bubble{ padding:10px 12px; overflow-wrap:anywhere; word-break:break-word; }
+  .ts,.msgMeta .small{ display:none; }
+
+  .inputBar{ position:sticky; bottom:0; z-index:120; gap:var(--space-1); padding:var(--space-1) var(--space-2) calc(var(--space-1) + env(safe-area-inset-bottom)); }
+  .inputBar input[type="text"]{ min-height:44px; font-size:16px; padding:10px 12px; }
+  .inputBar #sendBtn{ min-width:44px; width:44px; height:44px; padding:0; border-radius:12px; font-size:0; }
+  .inputBar #sendBtn::before{ content:"➤"; font-size:18px; }
+
+  .inputBar .tonePicker,
+  .dmInput .tonePicker{ margin-left:0; order:3; }
+  .toneMenuBtn{ min-height:40px; min-width:40px; width:40px; padding:0; border-radius:12px; font-size:0; border-left:0; }
+  .toneMenuBtn::before{ content:"🙂"; font-size:18px; }
+  .toneMenuPanel{ position:fixed; left:var(--space-2); right:var(--space-2); bottom:calc(56px + env(safe-area-inset-bottom)); min-width:0; width:auto; max-width:none; border-radius:14px; }
+
+  .modal{ align-items:flex-end; padding:var(--space-1); }
+  .modalCard{ width:100%; max-width:100%; border-radius:16px 16px 12px 12px; }
+  .modalBody{ padding:0 var(--space-2) var(--space-2); }
+}
+
+@media (min-width: 769px) and (max-width: 1024px){ .topbar{ padding:0 var(--space-3); } }
+@media (min-width: 1025px){ .topbar{ padding:0 var(--space-3); } }


### PR DESCRIPTION
### Motivation
- The mobile chat experience was cramped, noisy, and not optimized for touch, so a mobile-first layout and spacing system were needed to improve readability and thumb reach. 
- The Games trigger was text-heavy and its opener could fail when the Games UI wiring was absent, so the button and opener needed simplification and a reliable fallback.

### Description
- Added a mobile-first CSS override block that introduces spacing tokens (`--space-1/2/3`), enforces `max-width:100%`/`min-width:0` on key containers, prevents horizontal overflow, and normalizes message, topbar, composer, and modal spacing in `public/styles.css`.
- Reduced the top bar height, moved to icon-only compact controls with consistent 40px touch targets, and added truncation for the room/title to prevent overflow in `public/styles.css` and `public/index.html`.
- Redesigned the composer for mobile by making the input sticky to bottom with safe-area padding, increasing input font-size to `16px` and min-height to `44px`, compacting the send button to an icon tap target, and moving the tone picker to an overlay so it does not reflow the composer in `public/styles.css`.
- Converted the top-bar Games button to icon-only in `public/index.html` and hardened `openGamesMenu()` in `public/app.js` to fall back to directly revealing the Games modal when the Games UI helper is not present.

### Testing
- Ran `git status --short` to verify working tree changes and it reported the three modified files successfully. (passed)
- Searched modified files with `rg -n "gamesOpenBtn|openGamesMenu\(|Mobile-first UI/UX cleanup|toneMenuBtn::before|sendBtn::before"` to confirm the new hooks and CSS tokens were applied. (passed)
- Committed the changes with `git add public/index.html public/app.js public/styles.css && git commit -m "Overhaul mobile chat UI layout and composer interactions"`, producing a successful commit. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e95a2be88333b6369820a2182fb1)