### PR TITLE
Implement unified YouTubeEmbed component using YouTube IFrame API

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -8761,40 +8761,17 @@ const MusicRoomPlayer = (() => {
 })();
 
 function buildYouTubePreview(videoId){
-  const btn = document.createElement("button");
-  btn.type = "button";
-  btn.className = "ytMiniCard";
-  btn.innerHTML = `
-    <div class="ytMiniThumb" aria-hidden="true"></div>
-    <div class="ytMiniMeta">
-      <div class="ytMiniTitle">YouTube video</div>
-      <div class="ytMiniChannel">Tap to play</div>
-    </div>
-    <div class="ytMiniAction">▶ Play</div>
-  `;
-  const thumb = btn.querySelector(".ytMiniThumb");
-  const titleEl = btn.querySelector(".ytMiniTitle");
-  const channelEl = btn.querySelector(".ytMiniChannel");
-
-  function applyMeta(meta){
-    if(!meta) return;
-    if(titleEl) titleEl.textContent = meta.title || "YouTube video";
-    if(channelEl) channelEl.textContent = meta.channel || "YouTube";
-    if(thumb) thumb.style.backgroundImage = meta.thumbnail ? `url(${meta.thumbnail})` : "";
+  const root = document.createElement("div");
+  root.className = "ytEmbedHost";
+  if(!window.YouTubeEmbed){
+    root.textContent = "YouTube player unavailable.";
+    return root;
   }
-
-  btn.addEventListener("click", (e)=>{
-    e.stopPropagation();
-    const cached = YOUTUBE_META_CACHE.get(videoId) || {};
-    StickyYouTubePlayer.loadVideo(videoId, cached, { autoplay:true });
-  });
-
-  const cachedMeta = YOUTUBE_META_CACHE.get(videoId);
-  if(cachedMeta) applyMeta(cachedMeta);
-  else fetchYouTubeMeta(videoId).then(meta => { if(meta) applyMeta(meta); });
-
-  return btn;
+  const cached = YOUTUBE_META_CACHE.get(videoId) || {};
+  new window.YouTubeEmbed(root, { videoId, meta: cached });
+  return root;
 }
+
 
 function diceFace(val){ return DICE_FACES[val - 1] || val || ""; }
 function fmtAbs(ts){

--- a/public/index.html
+++ b/public/index.html
@@ -2492,6 +2492,7 @@
 <script defer="" src="/games/gamesMenu.js"></script>
 <script type="module" src="/dndCharacterWizardData.js"></script>
 <script type="module" src="/dndCharacterWizard.js"></script>
+<script defer="" src="/youtube-embed.js"></script>
 <script defer="" src="/app.js"></script>
 <div id="modalRoot">
 <!-- STAFF: Kick/Ban Appeals Panel -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -16867,3 +16867,12 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
 
 @media (min-width: 769px) and (max-width: 1024px){ .topbar{ padding:0 var(--space-3); } }
 @media (min-width: 1025px){ .topbar{ padding:0 var(--space-3); } }
+.ytEmbedAspect{position:relative;aspect-ratio:16/9;width:100%;background:#111;border-radius:12px;overflow:hidden}
+.ytEmbedPoster,.ytEmbedPlayer,.ytEmbedPlayer iframe,.ytEmbedError{position:absolute;inset:0;width:100%;height:100%}
+.ytEmbedPoster{background-size:cover;background-position:center;border:0;cursor:pointer}
+.ytEmbedError{display:grid;place-content:center;gap:8px;color:#fff;background:#1b1b1b}
+.ytEmbedControls{position:absolute;left:0;right:0;bottom:0;display:flex;align-items:center;gap:8px;padding:8px;background:linear-gradient(transparent,rgba(0,0,0,.75));opacity:0;transition:opacity .2s}
+.ytEmbed:hover .ytEmbedControls{opacity:1}
+.ytEmbed .ytPlay,.ytEmbed .ytMute,.ytEmbed .ytFs,.ytEmbed summary{min-width:44px;min-height:44px}
+.ytSeek,.ytVolume{flex:1}
+@media (max-width: 768px){.ytEmbedControls{opacity:1}.ytVolume,.ytTime{display:none}.ytSecondary{display:grid;gap:8px;background:#000d;padding:8px;border-radius:8px;position:absolute;right:0;bottom:48px}}

--- a/public/youtube-embed.js
+++ b/public/youtube-embed.js
@@ -1,0 +1,123 @@
+(function(global){
+  const API_SRC = "https://www.youtube.com/iframe_api";
+  const PLAYER_VARS = { playsinline: 1, modestbranding: 1, rel: 0, controls: 0, enablejsapi: 1, origin: window.location.origin };
+  let apiPromise = null;
+  const activePlayers = new Set();
+
+  function loadApi(){
+    if(global.YT?.Player) return Promise.resolve(global.YT);
+    if(apiPromise) return apiPromise;
+    apiPromise = new Promise((resolve, reject)=>{
+      const prev = global.onYouTubeIframeAPIReady;
+      global.onYouTubeIframeAPIReady = () => { prev?.(); resolve(global.YT); };
+      const script = document.createElement('script');
+      script.src = API_SRC;
+      script.async = true;
+      script.onerror = () => reject(new Error('yt-api-load-failure'));
+      document.head.appendChild(script);
+    });
+    return apiPromise;
+  }
+
+  function extractVideoId(input){
+    if(!input) return null;
+    const v = String(input).trim();
+    if(/^[A-Za-z0-9_-]{6,}$/.test(v)) return v;
+    const m = v.match(/(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/)|youtu\.be\/)([A-Za-z0-9_-]{6,})/i);
+    return m ? m[1] : null;
+  }
+
+  function pauseOtherPlayers(current){
+    activePlayers.forEach(player=>{ if(player !== current) player.pauseVideo?.(); });
+  }
+
+  class YouTubeEmbed {
+    constructor(el, opts={}){
+      this.el = el;
+      this.opts = opts;
+      this.videoId = extractVideoId(opts.videoId || opts.url);
+      this.player = null;
+      this.state = { playing:false, muted:false, volume:100, time:0, duration:0, qualities:[], speeds:[] };
+      this.progressTimer = null;
+      this.intersectionObserver = null;
+      this.booted = false;
+      this.buildShell();
+      this.observe();
+    }
+
+    buildShell(){
+      this.el.classList.add('ytEmbed');
+      this.el.innerHTML = `
+        <div class="ytEmbedAspect">
+          <button class="ytEmbedPoster" type="button" aria-label="Play video"></button>
+          <div class="ytEmbedPlayer" hidden></div>
+          <div class="ytEmbedError" hidden><p>Video unavailable.</p><button type="button" class="ytRetry">Retry</button></div>
+          <div class="ytEmbedControls">
+            <button type="button" class="ytPlay">▶</button><input class="ytSeek" type="range" min="0" max="0" value="0" />
+            <span class="ytTime">0:00 / 0:00</span><button type="button" class="ytMute">🔊</button><input class="ytVolume" type="range" min="0" max="100" value="100" />
+            <button type="button" class="ytFs">⛶</button><details class="ytMore"><summary>⋯</summary><div class="ytSecondary"><select class="ytSpeed"></select><select class="ytQuality"></select><a class="ytOpen" target="_blank" rel="noopener">YouTube</a></div></details>
+          </div>
+        </div>`;
+      this.poster = this.el.querySelector('.ytEmbedPoster');
+      this.playerHost = this.el.querySelector('.ytEmbedPlayer');
+      this.err = this.el.querySelector('.ytEmbedError');
+      this.playBtn = this.el.querySelector('.ytPlay');
+      this.seek = this.el.querySelector('.ytSeek');
+      this.time = this.el.querySelector('.ytTime');
+      this.muteBtn = this.el.querySelector('.ytMute');
+      this.volume = this.el.querySelector('.ytVolume');
+      this.fs = this.el.querySelector('.ytFs');
+      this.speed = this.el.querySelector('.ytSpeed');
+      this.quality = this.el.querySelector('.ytQuality');
+      this.open = this.el.querySelector('.ytOpen');
+      this.open.href = this.videoId ? `https://www.youtube.com/watch?v=${this.videoId}` : '#';
+      if(this.videoId) this.poster.style.backgroundImage = `url(https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg)`;
+      this.poster.addEventListener('click', ()=>this.initPlayer(true));
+      this.el.querySelector('.ytRetry').addEventListener('click', ()=>this.initPlayer(false, true));
+      this.playBtn.addEventListener('click', ()=>this.togglePlay());
+      this.seek.addEventListener('input', ()=>this.player?.seekTo(Number(this.seek.value), true));
+      this.volume.addEventListener('input', ()=>{ this.player?.setVolume(Number(this.volume.value)); this.player?.unMute?.(); this.sync(); });
+      this.muteBtn.addEventListener('click', ()=>{ if(this.player?.isMuted?.()) this.player.unMute(); else this.player?.mute(); this.sync(); });
+      this.fs.addEventListener('click', ()=> this.el.querySelector('.ytEmbedAspect').requestFullscreen?.());
+      this.speed.addEventListener('change', ()=> this.player?.setPlaybackRate?.(Number(this.speed.value)));
+      this.quality.addEventListener('change', ()=> this.player?.setPlaybackQuality?.(this.quality.value));
+    }
+    observe(){
+      this.intersectionObserver = new IntersectionObserver(entries=>{
+        entries.forEach(entry=>{ if(entry.isIntersecting && !this.booted) this.initPlayer(false); });
+      }, { rootMargin: '180px' });
+      this.intersectionObserver.observe(this.el);
+    }
+    async initPlayer(autoplay=false, force=false){
+      if(!this.videoId){ this.showError('Invalid YouTube URL'); return; }
+      if(this.player && !force){ if(autoplay) this.player.playVideo?.(); return; }
+      this.poster.hidden = true; this.playerHost.hidden = false; this.err.hidden = true;
+      try{
+        const YT = await loadApi();
+        this.booted = true;
+        this.player = new YT.Player(this.playerHost, { videoId:this.videoId, playerVars: PLAYER_VARS, events:{ onReady:()=>{ if(autoplay) this.player.playVideo?.(); this.populateSelectors(); this.sync(); }, onStateChange:(e)=>{ if(e.data===YT.PlayerState.PLAYING) pauseOtherPlayers(this.player); this.sync(); }, onError:()=> this.showError('Video unavailable') } });
+        activePlayers.add(this.player);
+      }catch{ this.showError('Failed to load YouTube API'); }
+    }
+    populateSelectors(){
+      const speeds = this.player?.getAvailablePlaybackRates?.() || [1];
+      this.speed.innerHTML = speeds.map(v=>`<option value="${v}">${v}x</option>`).join('');
+      const q = this.player?.getAvailableQualityLevels?.() || [];
+      if(q.length){ this.quality.innerHTML = q.map(v=>`<option value="${v}">${v}</option>`).join(''); }
+      else { this.quality.innerHTML = '<option value="default">Auto</option>'; }
+    }
+    togglePlay(){
+      const s = this.player?.getPlayerState?.();
+      if(s === global.YT?.PlayerState?.PLAYING) this.player.pauseVideo?.(); else this.player.playVideo?.();
+    }
+    sync(){
+      clearTimeout(this.progressTimer);
+      const run = ()=>{ if(!this.player) return; const d = Number(this.player.getDuration?.()||0), t=Number(this.player.getCurrentTime?.()||0); this.seek.max = d; this.seek.value=t; this.time.textContent=`${fmt(t)} / ${fmt(d)}`; this.playBtn.textContent = this.player.getPlayerState?.()===global.YT?.PlayerState?.PLAYING ? '❚❚' : '▶'; this.muteBtn.textContent = this.player.isMuted?.() ? '🔇':'🔊'; this.progressTimer = setTimeout(run, 250); };
+      run();
+    }
+    showError(msg){ this.err.hidden = false; this.err.querySelector('p').textContent = msg; this.poster.hidden = false; this.playerHost.hidden = true; }
+  }
+
+  function fmt(sec){ sec=Math.floor(sec||0); const m=Math.floor(sec/60); const s=String(sec%60).padStart(2,'0'); return `${m}:${s}`; }
+  global.YouTubeEmbed = YouTubeEmbed;
+})(window);


### PR DESCRIPTION
### Motivation
- Replace fragmented legacy YouTube preview/sticky-player code with a single, reusable embed implementation that is easier to maintain and more reliable across desktop and mobile.
- Improve UX with a modern overlay control set, strict 16:9 responsive sizing, and mobile-friendly large touch targets.
- Improve performance by lazy-loading the YouTube IFrame API and players only when needed and by preventing unnecessary re-initialization.
- Ensure consistent behavior across the app so only one video plays at a time and failures are handled gracefully.

### Description
- Added a new `public/youtube-embed.js` module which dynamically loads the YouTube IFrame API once, exposes a `YouTubeEmbed` class, and manages one player instance per embed with local UI state syncing and progress polling.
- Replaced the old mini-card preview in `public/app.js` (`buildYouTubePreview`) to instantiate `YouTubeEmbed` hosts directly so chat messages render the new component.
- Injected `youtube-embed.js` into `public/index.html` so the component is available before `app.js` runs.
- Added responsive, mobile-first styles in `public/styles.css` enforcing `aspect-ratio: 16/9`, hover-revealed controls on desktop, always-visible simplified controls on mobile, 44px minimum touch targets, and a poster thumbnail preview used for lazy initialization.
- Implemented controls and features: play/pause toggle, scrubbable seek bar, volume slider + mute, fullscreen toggle, playback speed selector, quality selector (uses `getAvailableQualityLevels()` when available with Auto fallback), "Open in YouTube" link, and a retry/fallback UI for invalid/private videos or API failures.
- Ensured global coordination so other active players are paused before a new embed plays, and avoided unnecessary iframe reloads by reusing existing player instances and guarding initialization with IntersectionObserver lazy-loading.

### Testing
- Ran static checks: `node --check public/youtube-embed.js` succeeded.
- Verified `node --check public/app.js` succeeded after updating `buildYouTubePreview` to use `YouTubeEmbed`.
- Verified `node --check server.js` to ensure server-side script validity; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f736547bb8833393c0041be9634a77)