### PR TITLE
Enhance music room with authoritative queue, metadata enrichment, and lyrics plumbing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7887,6 +7887,9 @@ const MusicRoomPlayer = (() => {
   let playerContainer = null;
   let currentVideoEl = null;
   let queueListEl = null;
+
+  let lyricsPanelEl = null;
+  let lyricsVisible = false;
   let apiReadyPromise = null;
   let currentVideo = null;
   let queue = [];
@@ -7984,6 +7987,7 @@ const MusicRoomPlayer = (() => {
             <button class="iconBtn" id="musicSkipBtn" title="Skip to next" aria-label="Skip to next">⏭</button>
             <button class="iconBtn" id="musicAudioOnlyBtn" title="Audio only mode" aria-label="Audio only mode">🎵</button>
             <button class="iconBtn" id="musicLowQualityBtn" title="Low quality mode" aria-label="Low quality mode">📶</button>
+            <button class="iconBtn" id="musicLyricsBtn" title="Toggle lyrics" aria-label="Toggle lyrics">📝</button>
           </div>
         </div>
         <div class="musicPlayerBody">
@@ -7992,6 +7996,7 @@ const MusicRoomPlayer = (() => {
         <div class="musicCurrentVideo" id="musicCurrentVideo">
           <div class="musicCurrentTitle">Nothing playing</div>
         </div>
+        <div class="musicLyricsPanel" id="musicLyricsPanel" hidden></div>
         <div class="musicQueue" id="musicQueue">
           <div class="musicQueueHeader">Queue</div>
           <div class="musicQueueList" id="musicQueueList"></div>
@@ -8004,12 +8009,14 @@ const MusicRoomPlayer = (() => {
     
     currentVideoEl = document.getElementById("musicCurrentVideo");
     queueListEl = document.getElementById("musicQueueList");
+    lyricsPanelEl = document.getElementById("musicLyricsPanel");
     
     // Setup controls
     const collapseBtn = document.getElementById("musicCollapseBtn");
     const skipBtn = document.getElementById("musicSkipBtn");
     const audioOnlyBtn = document.getElementById("musicAudioOnlyBtn");
     const lowQualityBtn = document.getElementById("musicLowQualityBtn");
+    const lyricsBtn = document.getElementById("musicLyricsBtn");
     
     if (collapseBtn) {
       collapseBtn.addEventListener("click", () => {
@@ -8032,6 +8039,12 @@ const MusicRoomPlayer = (() => {
     if (lowQualityBtn) {
       lowQualityBtn.addEventListener("click", () => {
         toggleLowQuality();
+      });
+    }
+    if (lyricsBtn) {
+      lyricsBtn.addEventListener("click", () => {
+        lyricsVisible = !lyricsVisible;
+        if (lyricsPanelEl) lyricsPanelEl.hidden = !lyricsVisible;
       });
     }
     
@@ -8060,6 +8073,7 @@ const MusicRoomPlayer = (() => {
       
       const audioOnlyBtn = document.getElementById("musicAudioOnlyBtn");
       const lowQualityBtn = document.getElementById("musicLowQualityBtn");
+    const lyricsBtn = document.getElementById("musicLyricsBtn");
       
       if (audioOnlyBtn) {
         audioOnlyBtn.classList.toggle("active", audioOnly);
@@ -8125,6 +8139,7 @@ const MusicRoomPlayer = (() => {
   function toggleLowQuality() {
     try {
       const lowQualityBtn = document.getElementById("musicLowQualityBtn");
+    const lyricsBtn = document.getElementById("musicLyricsBtn");
       const isActive = lowQualityBtn?.classList.toggle("active");
       localStorage.setItem(LOW_QUALITY_KEY, isActive ? "true" : "false");
       applyQualitySettings();
@@ -8529,7 +8544,7 @@ const MusicRoomPlayer = (() => {
     autoplayAttempted = false;
   }
 
-  async function playVideo(videoId, title, addedBy, startedAt) {
+  async function playVideo(videoId, title, addedBy, startedAt, artist, albumArt, duration) {
     // Wait until any in-progress load has fully completed before continuing.
     // This loops instead of using a single fixed delay to avoid overlapping loads
     // when the first load takes longer than OVERLAP_PREVENTION_DELAY_MS.
@@ -8543,16 +8558,24 @@ const MusicRoomPlayer = (() => {
       initDom();
       show();
       
-      currentVideo = { videoId, title, addedBy, startedAt };
+      currentVideo = { videoId, title, addedBy, startedAt, artist: arguments[4], albumArt: arguments[5], duration: arguments[6] };
       
       // Update current video display
       if (currentVideoEl) {
         currentVideoEl.innerHTML = `
           <div class="musicCurrentTitle">${escapeHtml(title)}</div>
-          <div class="musicCurrentMeta">Added by ${escapeHtml(addedBy)}</div>
+          <div class="musicCurrentMeta">Added by ${escapeHtml(addedBy)} • ${escapeHtml(currentVideo.artist || "Unknown Artist")}</div>
         `;
       }
       
+      if (lyricsPanelEl && artist && title) {
+        socket?.emit("music:lyrics:get", { artist, title }, (res) => {
+          if (!lyricsPanelEl) return;
+          const text = res?.lyrics || "Lyrics unavailable.";
+          lyricsPanelEl.textContent = text;
+        });
+      }
+
       await ensurePlayer();
       
       if (player) {
@@ -8623,13 +8646,17 @@ const MusicRoomPlayer = (() => {
     
     queueListEl.innerHTML = queue.map((item, index) => `
       <div class="musicQueueItem">
+        <button class="iconBtn musicQueueRemove" data-id="${item.id}" title="Remove">✖</button>
         <div class="musicQueueIndex">${index + 1}</div>
         <div class="musicQueueInfo">
           <div class="musicQueueTitle">${escapeHtml(item.title)}</div>
-          <div class="musicQueueMeta">Added by ${escapeHtml(item.addedBy)}</div>
+          <div class="musicQueueMeta">Added by ${escapeHtml(item.addedBy)}${item.artist ? ` • ${escapeHtml(item.artist)}` : ""}</div>
         </div>
       </div>
     `).join('');
+    queueListEl.querySelectorAll('.musicQueueRemove').forEach((btn)=>{
+      btn.addEventListener('click', ()=> socket?.emit('music:queue:remove', { id: Number(btn.dataset.id) }));
+    });
   }
 
   function stop() {
@@ -27658,7 +27685,7 @@ socket.on("mod:case_event", (payload = {}) => {
   // Music Room Player events
   socket.on("music:play", (payload) => {
     if (currentRoom === "music") {
-      MusicRoomPlayer.playVideo(payload.videoId, payload.title, payload.addedBy, payload.startedAt);
+      MusicRoomPlayer.playVideo(payload.videoId, payload.title, payload.addedBy, payload.startedAt, payload.artist, payload.albumArt, payload.duration);
     }
   });
 

--- a/server.js
+++ b/server.js
@@ -74,7 +74,7 @@ const VALID_DND_ROOM_NAMES = ["dnd", "dndstoryroom", "dndstory", "justdnd"];
 
 // Music Room Global Player Queue
 const MUSIC_ROOM_QUEUE = {
-  queue: [], // Array of { videoId, title, addedBy, addedAt, queueId }
+  queue: [], // Array of { id, videoId, title, duration, thumbnail, addedBy, votes, artist, albumArt }
   currentVideo: null, // { videoId, title, startedAt, addedBy }
   nowPlaying: false,
   nextQueueId: 1, // Counter for queue ordering
@@ -86,6 +86,8 @@ const MUSIC_ROOM_QUEUE = {
   elapsedBeforePause: 0, // Seconds elapsed before pause
   syncInterval: null  // Store interval ID for cleanup
 };
+const MUSIC_METADATA_CACHE = new Map();
+const MUSIC_LYRICS_CACHE = new Map();
 const MUSIC_QUEUE_MAX_SIZE = 100; // Maximum queue size
 
 // Music sync timing constants
@@ -233,6 +235,45 @@ async function fetchYouTubeTitle(videoId) {
   }
 }
 
+async function fetchTrackMetadata(videoId) {
+  const cacheKey = String(videoId || "").trim();
+  if (!cacheKey) return null;
+  if (MUSIC_METADATA_CACHE.has(cacheKey)) return MUSIC_METADATA_CACHE.get(cacheKey);
+  try {
+    const url = `https://noembed.com/embed?url=https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const data = await response.json();
+    const meta = {
+      artist: data?.author_name || "Unknown Artist",
+      albumArt: data?.thumbnail_url || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+      thumbnail: data?.thumbnail_url || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+      duration: null
+    };
+    MUSIC_METADATA_CACHE.set(cacheKey, meta);
+    return meta;
+  } catch (_err) {
+    return null;
+  }
+}
+
+async function fetchLyrics(artist, title) {
+  const key = `${String(artist || "").toLowerCase()}::${String(title || "").toLowerCase()}`;
+  if (!artist || !title) return null;
+  if (MUSIC_LYRICS_CACHE.has(key)) return MUSIC_LYRICS_CACHE.get(key);
+  try {
+    const url = `https://api.lyrics.ovh/v1/${encodeURIComponent(artist)}/${encodeURIComponent(title)}`;
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const data = await response.json();
+    const lyrics = data?.lyrics || null;
+    if (lyrics) MUSIC_LYRICS_CACHE.set(key, lyrics);
+    return lyrics;
+  } catch (_err) {
+    return null;
+  }
+}
+
 // Helper to shuffle an array using Fisher-Yates algorithm
 function shuffleArray(array) {
   for (let i = array.length - 1; i > 0; i--) {
@@ -368,10 +409,14 @@ function skipToNextVideo(io) {
   if (MUSIC_ROOM_QUEUE.queue.length > 0) {
     const video = MUSIC_ROOM_QUEUE.queue.shift();
     MUSIC_ROOM_QUEUE.currentVideo = {
+      id: video.id,
       videoId: video.videoId,
       title: video.title,
       startedAt: Date.now(),
-      addedBy: video.addedBy
+      addedBy: video.addedBy,
+      artist: video.artist || "Unknown Artist",
+      albumArt: video.albumArt || video.thumbnail || null,
+      duration: video.duration || null
     };
     MUSIC_ROOM_QUEUE.nowPlaying = true;
     
@@ -385,7 +430,10 @@ function skipToNextVideo(io) {
       videoId: video.videoId,
       title: video.title,
       addedBy: video.addedBy,
-      startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt
+      startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt,
+      artist: MUSIC_ROOM_QUEUE.currentVideo.artist,
+      albumArt: MUSIC_ROOM_QUEUE.currentVideo.albumArt,
+      duration: MUSIC_ROOM_QUEUE.currentVideo.duration
     });
     
     // Start sync broadcast now that video playback has begun
@@ -20754,17 +20802,28 @@ if (!room) {
                   // Add to queue with placeholder title first to preserve order
                   const queueId = MUSIC_ROOM_QUEUE.nextQueueId++;
                   const queueEntry = {
+                    id: queueId,
                     videoId,
                     title: "Loading...",
+                    duration: null,
+                    thumbnail: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
                     addedBy: socket.user.username,
                     addedAt: Date.now(),
-                    queueId
+                    queueId,
+                    votes: 0
                   };
                   MUSIC_ROOM_QUEUE.queue.push(queueEntry);
 
                   // Fetch title asynchronously and update
                   const title = await fetchYouTubeTitle(videoId) || "Unknown Video";
                   queueEntry.title = title;
+                  const metadata = await fetchTrackMetadata(videoId);
+                  if (metadata) {
+                    queueEntry.artist = metadata.artist;
+                    queueEntry.albumArt = metadata.albumArt;
+                    queueEntry.thumbnail = metadata.thumbnail || queueEntry.thumbnail;
+                    queueEntry.duration = metadata.duration || null;
+                  }
 
                   // Send system message using emitRoomSystem
                   emitRoomSystem(room, `${socket.user.username} added: ${title}`);
@@ -20773,10 +20832,14 @@ if (!room) {
                   if (!MUSIC_ROOM_QUEUE.currentVideo && MUSIC_ROOM_QUEUE.queue.length === 1) {
                     const video = MUSIC_ROOM_QUEUE.queue.shift();
                     MUSIC_ROOM_QUEUE.currentVideo = {
+                      id: video.id,
                       videoId: video.videoId,
                       title: video.title,
                       startedAt: Date.now(),
-                      addedBy: video.addedBy
+                      addedBy: video.addedBy,
+                      artist: video.artist || "Unknown Artist",
+                      albumArt: video.albumArt || video.thumbnail || null,
+                      duration: video.duration || null
                     };
                     MUSIC_ROOM_QUEUE.nowPlaying = true;
                     
@@ -20791,7 +20854,10 @@ if (!room) {
                       videoId: video.videoId,
                       title: video.title,
                       addedBy: video.addedBy,
-                      startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt
+                      startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt,
+                      artist: MUSIC_ROOM_QUEUE.currentVideo.artist,
+                      albumArt: MUSIC_ROOM_QUEUE.currentVideo.albumArt,
+                      duration: MUSIC_ROOM_QUEUE.currentVideo.duration
                     });
                     
                     // Start periodic sync broadcast
@@ -21037,10 +21103,14 @@ if (!room) {
     if (MUSIC_ROOM_QUEUE.queue.length > 0) {
       const video = MUSIC_ROOM_QUEUE.queue.shift();
       MUSIC_ROOM_QUEUE.currentVideo = {
+        id: video.id,
         videoId: video.videoId,
         title: video.title,
         startedAt: Date.now(),
-        addedBy: video.addedBy
+        addedBy: video.addedBy,
+        artist: video.artist || "Unknown Artist",
+        albumArt: video.albumArt || video.thumbnail || null,
+        duration: video.duration || null
       };
       MUSIC_ROOM_QUEUE.nowPlaying = true;
       
@@ -21054,7 +21124,10 @@ if (!room) {
         videoId: video.videoId,
         title: video.title,
         addedBy: video.addedBy,
-        startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt
+        startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt,
+        artist: MUSIC_ROOM_QUEUE.currentVideo.artist,
+        albumArt: MUSIC_ROOM_QUEUE.currentVideo.albumArt,
+        duration: MUSIC_ROOM_QUEUE.currentVideo.duration
       });
       
       // Start periodic sync broadcast
@@ -21095,10 +21168,14 @@ if (!room) {
     if (MUSIC_ROOM_QUEUE.queue.length > 0) {
       const video = MUSIC_ROOM_QUEUE.queue.shift();
       MUSIC_ROOM_QUEUE.currentVideo = {
+        id: video.id,
         videoId: video.videoId,
         title: video.title,
         startedAt: Date.now(),
-        addedBy: video.addedBy
+        addedBy: video.addedBy,
+        artist: video.artist || "Unknown Artist",
+        albumArt: video.albumArt || video.thumbnail || null,
+        duration: video.duration || null
       };
       MUSIC_ROOM_QUEUE.nowPlaying = true;
       
@@ -21112,7 +21189,10 @@ if (!room) {
         videoId: video.videoId,
         title: video.title,
         addedBy: video.addedBy,
-        startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt
+        startedAt: MUSIC_ROOM_QUEUE.currentVideo.startedAt,
+        artist: MUSIC_ROOM_QUEUE.currentVideo.artist,
+        albumArt: MUSIC_ROOM_QUEUE.currentVideo.albumArt,
+        duration: MUSIC_ROOM_QUEUE.currentVideo.duration
       });
       
       // Start periodic sync broadcast
@@ -21212,6 +21292,32 @@ if (!room) {
         }
       });
     }
+  });
+
+  socket.on("music:queue:remove", ({ id } = {}) => {
+    if (socket.currentRoom !== "music") return;
+    const targetId = Number(id);
+    if (!Number.isInteger(targetId)) return;
+    MUSIC_ROOM_QUEUE.queue = MUSIC_ROOM_QUEUE.queue.filter((item) => Number(item.id) !== targetId);
+    io.to("music").emit("music:queue", { queue: MUSIC_ROOM_QUEUE.queue, current: MUSIC_ROOM_QUEUE.currentVideo });
+  });
+
+  socket.on("music:queue:reorder", ({ fromIndex, toIndex } = {}) => {
+    if (socket.currentRoom !== "music") return;
+    if (!isMusicModerator(socket.user)) return;
+    const from = Number(fromIndex);
+    const to = Number(toIndex);
+    if (!Number.isInteger(from) || !Number.isInteger(to)) return;
+    if (from < 0 || to < 0 || from >= MUSIC_ROOM_QUEUE.queue.length || to >= MUSIC_ROOM_QUEUE.queue.length) return;
+    const [moved] = MUSIC_ROOM_QUEUE.queue.splice(from, 1);
+    MUSIC_ROOM_QUEUE.queue.splice(to, 0, moved);
+    io.to("music").emit("music:queue", { queue: MUSIC_ROOM_QUEUE.queue, current: MUSIC_ROOM_QUEUE.currentVideo });
+  });
+
+  socket.on("music:lyrics:get", async ({ artist, title } = {}, ack) => {
+    if (socket.currentRoom !== "music") return;
+    const lyrics = await fetchLyrics(artist, title);
+    if (typeof ack === "function") ack({ ok: true, lyrics: lyrics || "" });
   });
 
   // Music voting handlers


### PR DESCRIPTION
### Motivation
- Evolve the simple YouTube sync into a Spotify-like shared queue with richer item metadata and optional lyrics without blocking playback.
- Ensure the server remains authoritative for queue state and playback transitions while clients receive enriched now-playing/queue payloads.

### Description
- Expanded the server queue model to store richer fields per item (`id`, `videoId`, `title`, `duration`, `thumbnail`, `addedBy`, `votes`, plus `artist`/`albumArt`) and added in-memory caches (`MUSIC_METADATA_CACHE`, `MUSIC_LYRICS_CACHE`).
- Added non-blocking metadata and lyrics helpers `fetchTrackMetadata` (via `noembed`) and `fetchLyrics` (via `lyrics.ovh`), and populate queue entries asynchronously when links are added.
- Propagated enriched now-playing payloads (artist, album art, duration) and preserved server-authoritative transitions and sync broadcasts; queue transitions reuse the same authoritative logic (including `skipToNextVideo`, `music:ended`, etc.).
- Implemented socket endpoints for authoritative queue management (`music:queue:remove`, `music:queue:reorder`) and a lyrics RPC (`music:lyrics:get`), and updated the client UI to add a lyrics panel, toggle button, per-item remove controls, and to lazy-fetch lyrics on track start.

### Testing
- Ran `node scripts/test-music-room.js` and all checks passed.
- Ran `node scripts/test-music-sync.js` and all synchronization tests passed.
- Automated tests validated that server sync broadcasting, client sync handlers, and queue ingestion/transition logic remain functional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7388d2bf08333a27a6138e5add8cd)