### PR TITLE
Unify music-room modal as primary player; add read-only timestamps and lyrics wiring

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7885,6 +7885,12 @@ const StickyYouTubePlayer = (()=>{
 const MusicRoomPlayer = (() => {
   let player = null;
   let playerContainer = null;
+  let musicModalEl = null;
+  let lyricsCache = new Map();
+  let timeDisplayEl = null;
+  let syncBadgeEl = null;
+  let albumArtEl = null;
+  let timeTicker = null;
   let currentVideoEl = null;
   let queueListEl = null;
 
@@ -7904,6 +7910,7 @@ const MusicRoomPlayer = (() => {
   const COLLAPSED_KEY = "music_collapsed";
   const POSITION_KEY = "music_player_position";
   const SIZE_KEY = "music_player_size";
+  const LYRICS_UNAVAILABLE = "Lyrics unavailable.";
   
   // Video loading timing constants
   const VIDEO_STOP_DELAY_MS = 200; // Time to wait for video to stop before loading new one
@@ -7972,44 +7979,17 @@ const MusicRoomPlayer = (() => {
   }
 
   function initDom() {
-    if (playerContainer) return; // Already initialized
-    
-    // Create player container
-    playerContainer = document.createElement("div");
-    playerContainer.id = "musicRoomPlayer";
-    playerContainer.className = "musicRoomPlayer is-hidden";
-    playerContainer.innerHTML = `
-      <div class="musicPlayerInner">
-        <div class="musicPlayerHeader" id="musicPlayerHeader">
-          <div class="musicPlayerTitle">🎵 Music Room Player</div>
-          <div class="musicPlayerControls">
-            <button class="iconBtn" id="musicCollapseBtn" title="Collapse player" aria-label="Collapse player">▼</button>
-            <button class="iconBtn" id="musicSkipBtn" title="Skip to next" aria-label="Skip to next">⏭</button>
-            <button class="iconBtn" id="musicAudioOnlyBtn" title="Audio only mode" aria-label="Audio only mode">🎵</button>
-            <button class="iconBtn" id="musicLowQualityBtn" title="Low quality mode" aria-label="Low quality mode">📶</button>
-            <button class="iconBtn" id="musicLyricsBtn" title="Toggle lyrics" aria-label="Toggle lyrics">📝</button>
-          </div>
-        </div>
-        <div class="musicPlayerBody">
-          <div id="musicPlayerFrame"></div>
-        </div>
-        <div class="musicCurrentVideo" id="musicCurrentVideo">
-          <div class="musicCurrentTitle">Nothing playing</div>
-        </div>
-        <div class="musicLyricsPanel" id="musicLyricsPanel" hidden></div>
-        <div class="musicQueue" id="musicQueue">
-          <div class="musicQueueHeader">Queue</div>
-          <div class="musicQueueList" id="musicQueueList"></div>
-        </div>
-        <div class="musicPlayerResizeHandle" id="musicPlayerResizeHandle"></div>
-      </div>
-    `;
-    
-    document.body.appendChild(playerContainer);
+    if (playerContainer) return;
+    playerContainer = document.getElementById("musicRoomExperienceModal");
+    musicModalEl = playerContainer;
+    if (!playerContainer) return;
     
     currentVideoEl = document.getElementById("musicCurrentVideo");
     queueListEl = document.getElementById("musicQueueList");
-    lyricsPanelEl = document.getElementById("musicLyricsPanel");
+    lyricsPanelEl = document.getElementById("musicRoomLyricsPanel");
+    timeDisplayEl = document.getElementById("musicTimeDisplay");
+    syncBadgeEl = document.getElementById("musicSyncBadge");
+    albumArtEl = document.getElementById("musicAlbumArtImage");
     
     // Setup controls
     const collapseBtn = document.getElementById("musicCollapseBtn");
@@ -8020,7 +8000,8 @@ const MusicRoomPlayer = (() => {
     
     if (collapseBtn) {
       collapseBtn.addEventListener("click", () => {
-        toggleCollapse();
+        const closeBtn = document.getElementById("musicRoomClose");
+        closeBtn?.click();
       });
     }
     
@@ -8044,22 +8025,9 @@ const MusicRoomPlayer = (() => {
     if (lyricsBtn) {
       lyricsBtn.addEventListener("click", () => {
         lyricsVisible = !lyricsVisible;
-        if (lyricsPanelEl) lyricsPanelEl.hidden = !lyricsVisible;
+        if (lyricsPanelEl) lyricsPanelEl.classList.toggle("is-hidden", !lyricsVisible);
       });
     }
-    
-    // Setup drag and resize handlers (desktop only)
-    setupDragAndResize();
-    
-    // Re-apply positioning when window is resized (to handle desktop/mobile transitions)
-    // Debounced to avoid excessive calls during window resizing
-    let resizeTimeout;
-    window.addEventListener("resize", () => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(() => {
-        updatePlayerLayout(); // Only update layout, don't re-attach listeners
-      }, 250);
-    }, { passive: true });
     
     // Load saved preferences
     loadUserPreferences();
@@ -8465,6 +8433,15 @@ const MusicRoomPlayer = (() => {
           }, AUTOPLAY_DELAY_MS);
         },
         onStateChange: (event) => {
+          refreshTimeDisplay();
+          if (event.data === YT.PlayerState.PLAYING) {
+            if (!timeTicker) timeTicker = setInterval(refreshTimeDisplay, 1000);
+          } else if (event.data === YT.PlayerState.PAUSED || event.data === YT.PlayerState.ENDED) {
+            if (timeTicker) {
+              clearInterval(timeTicker);
+              timeTicker = null;
+            }
+          }
           if (event.data === YT.PlayerState.ENDED) {
             // Check if loop is enabled
             if (musicControlsState?.loopEnabled && currentVideo) {
@@ -8516,7 +8493,7 @@ const MusicRoomPlayer = (() => {
   function show() {
     initDom();
     if (playerContainer) {
-      playerContainer.classList.remove("is-hidden");
+      playerContainer.hidden = false;
     }
     
     // Start periodic autoplay checking (in case autoplay was blocked)
@@ -8529,7 +8506,7 @@ const MusicRoomPlayer = (() => {
 
   function hide() {
     if (playerContainer) {
-      playerContainer.classList.add("is-hidden");
+      playerContainer.hidden = true;
     }
     if (player) {
       try { player.stopVideo?.(); } catch (err) { clientLogger.warn("Suppressed client error", err); }
@@ -8542,6 +8519,25 @@ const MusicRoomPlayer = (() => {
     }
     
     autoplayAttempted = false;
+    if (timeTicker) {
+      clearInterval(timeTicker);
+      timeTicker = null;
+    }
+  }
+
+  function formatClock(value) {
+    const seconds = Math.max(0, Math.floor(Number(value) || 0));
+    const mm = Math.floor(seconds / 60);
+    const ss = seconds % 60;
+    return `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+  }
+
+  function refreshTimeDisplay() {
+    const current = player?.getCurrentTime?.() || 0;
+    const total = player?.getDuration?.() || currentVideo?.duration || 0;
+    const line = `${formatClock(current)} / ${formatClock(total)}`;
+    if (timeDisplayEl) timeDisplayEl.textContent = line;
+    if (syncBadgeEl) syncBadgeEl.textContent = `Synced • ${line}`;
   }
 
   async function playVideo(videoId, title, addedBy, startedAt, artist, albumArt, duration) {
@@ -8558,7 +8554,7 @@ const MusicRoomPlayer = (() => {
       initDom();
       show();
       
-      currentVideo = { videoId, title, addedBy, startedAt, artist: arguments[4], albumArt: arguments[5], duration: arguments[6] };
+      currentVideo = { videoId, title, addedBy, startedAt, artist, albumArt, duration };
       
       // Update current video display
       if (currentVideoEl) {
@@ -8567,13 +8563,25 @@ const MusicRoomPlayer = (() => {
           <div class="musicCurrentMeta">Added by ${escapeHtml(addedBy)} • ${escapeHtml(currentVideo.artist || "Unknown Artist")}</div>
         `;
       }
+      if (albumArtEl) {
+        albumArtEl.src = albumArt || `https://i.ytimg.com/vi/${encodeURIComponent(videoId)}/hqdefault.jpg`;
+      }
       
-      if (lyricsPanelEl && artist && title) {
-        socket?.emit("music:lyrics:get", { artist, title }, (res) => {
-          if (!lyricsPanelEl) return;
-          const text = res?.lyrics || "Lyrics unavailable.";
-          lyricsPanelEl.textContent = text;
-        });
+      const lyricsContentEl = document.getElementById("musicLyricsContent");
+      if (lyricsContentEl) {
+        const key = `${String(artist || "").toLowerCase()}::${String(title || "").toLowerCase()}`;
+        if (artist && title && lyricsCache.has(key)) {
+          lyricsContentEl.textContent = lyricsCache.get(key) || LYRICS_UNAVAILABLE;
+        } else if (artist && title) {
+          lyricsContentEl.textContent = "Loading lyrics...";
+          socket?.emit("music:lyrics:get", { artist, title }, (res) => {
+            const text = (res?.lyrics || "").trim() || LYRICS_UNAVAILABLE;
+            lyricsCache.set(key, text);
+            if (document.getElementById("musicLyricsContent")) document.getElementById("musicLyricsContent").textContent = text;
+          });
+        } else {
+          lyricsContentEl.textContent = LYRICS_UNAVAILABLE;
+        }
       }
 
       await ensurePlayer();
@@ -8624,6 +8632,7 @@ const MusicRoomPlayer = (() => {
           // Apply quality settings after player has time to initialize
           setTimeout(() => {
             applyQualitySettings();
+            refreshTimeDisplay();
           }, QUALITY_APPLY_DELAY_MS);
         } catch (err) {
           console.warn("[MusicRoomPlayer] Failed to play video:", err);
@@ -8667,12 +8676,14 @@ const MusicRoomPlayer = (() => {
     if (player) {
       try { player.stopVideo?.(); } catch (err) { clientLogger.warn("Suppressed client error", err); }
     }
+    refreshTimeDisplay();
   }
 
   function pause() {
     if (player && typeof player.pauseVideo === "function") {
       try {
         player.pauseVideo();
+        refreshTimeDisplay();
       } catch (err) {
         console.warn("[MusicRoomPlayer] Failed to pause:", err);
       }
@@ -8700,6 +8711,7 @@ const MusicRoomPlayer = (() => {
         // Resume playback
         if (typeof player.playVideo === "function") {
           player.playVideo();
+          refreshTimeDisplay();
         }
       } catch (err) {
         console.warn("[MusicRoomPlayer] Failed to resume:", err);
@@ -18055,7 +18067,15 @@ function joinRoom(room){
     // Request current state when joining music room
     socket?.emit("music:getState", (state) => {
       if (state.current) {
-        MusicRoomPlayer.playVideo(state.current.videoId, state.current.title, state.current.addedBy, state.current.startedAt);
+        MusicRoomPlayer.playVideo(
+          state.current.videoId,
+          state.current.title,
+          state.current.addedBy,
+          state.current.startedAt,
+          state.current.artist,
+          state.current.albumArt,
+          state.current.duration
+        );
       }
       if (state.queue) {
         MusicRoomPlayer.updateQueue(state.queue);
@@ -28859,7 +28879,7 @@ composerForm?.addEventListener("submit", e => {
   const modal = document.getElementById('musicRoomExperienceModal');
   const closeBtn = document.getElementById('musicRoomClose');
   const toggleLyricsBtn = document.getElementById('musicRoomToggleLyrics');
-  const lyricsPanel = document.getElementById('musicLyricsPanel');
+  const lyricsPanel = document.getElementById('musicRoomLyricsPanel');
   const queuePanel = document.getElementById('musicQueuePanel');
   const chatPanel = document.getElementById('musicChatPanel');
   const musicBtn = document.getElementById('musicControlsBtn');

--- a/public/index.html
+++ b/public/index.html
@@ -3097,7 +3097,7 @@
       <div class="musicRoomNow">
         <span class="musicRoomDot" aria-hidden="true"></span>
         <strong id="musicRoomExperienceTitle">Music Room</strong>
-        <span class="musicRoomSyncBadge" id="musicSyncBadge">Synced • 00:42</span>
+        <span class="musicRoomSyncBadge" id="musicSyncBadge">Synced • 00:00 / 00:00</span>
       </div>
       <div class="musicRoomTopActions">
         <button class="iconBtn" id="musicRoomToggleLyrics" type="button" aria-pressed="true">Lyrics</button>
@@ -3107,33 +3107,31 @@
 
     <div class="musicRoomLayout">
       <aside class="musicQueuePanel" id="musicQueuePanel">
-        <header><strong>Up Next</strong><span>8 tracks</span></header>
-        <ul class="musicQueueList">
-          <li class="active" draggable="true"><img src="/icons/3410/gem-01.png" alt=""><div><strong>Midnight Echo</strong><span>Luma Sky • added by Kai</span></div><div class="musicQueueActions"><button>▲</button><button>✕</button></div></li>
-          <li draggable="true"><img src="/icons/3410/gem-02.png" alt=""><div><strong>Velvet Neon</strong><span>Norell • added by Ivy</span></div><div class="musicQueueActions"><button>▲</button><button>✕</button></div></li>
-          <li draggable="true"><img src="/icons/3410/gem-03.png" alt=""><div><strong>Pulse Lane</strong><span>Astra • added by Ren</span></div><div class="musicQueueActions"><button>▲</button><button>✕</button></div></li>
-        </ul>
+        <header><strong>Up Next</strong><span>Room Queue</span></header>
+        <div class="musicQueueList" id="musicQueueList"></div>
       </aside>
       <section class="musicPlayerSection">
-        <div class="musicAlbumArt"><img src="/icons/3410/gem-16.png" alt="Album art"></div>
-        <div class="musicTrackMeta"><h3>Midnight Echo</h3><p>Luma Sky • Night Shift Deluxe</p></div>
-        <div class="musicProgressWrap"><div class="musicProgressBar"><span style="width:42%"></span></div><div class="musicProgressTime"><span>1:24</span><span>3:20</span></div></div>
-        <div class="musicControlRow"><button>⏮</button><button class="play">⏯</button><button>⏭</button><label>🔊<input type="range" min="0" max="100" value="70"></label><button>⚙</button></div>
-      </section>
-      <aside class="musicLyricsPanel" id="musicLyricsPanel">
-        <header><strong>Lyrics</strong><label><input type="checkbox" id="lyricsSyncToggle" checked> Sync</label></header>
-        <div class="musicLyricsBody">
-          <p>City lights are fading slow</p>
-          <p class="active">Hold the line, don’t let it go</p>
-          <p>Hearts in rhythm, breathing sound</p>
-          <p>All our shadows hit the ground</p>
+        <div class="musicAlbumArt"><img id="musicAlbumArtImage" src="/icons/3410/gem-16.png" alt="Album art"></div>
+        <div id="musicPlayerFrame"></div>
+        <div class="musicCurrentVideo" id="musicCurrentVideo"><div class="musicCurrentTitle">Nothing playing</div></div>
+        <div class="musicProgressWrap"><div class="musicProgressTime"><span id="musicTimeDisplay">00:00 / 00:00</span></div></div>
+        <div class="musicControlRow">
+          <button class="iconBtn" id="musicCollapseBtn" title="Close music room" aria-label="Close music room">✕</button>
+          <button class="iconBtn" id="musicSkipBtn" title="Skip to next" aria-label="Skip to next">⏭</button>
+          <button class="iconBtn" id="musicAudioOnlyBtn" title="Audio only mode" aria-label="Audio only mode">🎵</button>
+          <button class="iconBtn" id="musicLowQualityBtn" title="Low quality mode" aria-label="Low quality mode">📶</button>
+          <button class="iconBtn" id="musicLyricsBtn" title="Toggle lyrics" aria-label="Toggle lyrics">📝</button>
         </div>
+      </section>
+      <aside class="musicLyricsPanel" id="musicRoomLyricsPanel">
+        <header><strong>Lyrics</strong><small>Live</small></header>
+        <div class="musicLyricsBody" id="musicLyricsContent"><p>Lyrics unavailable.</p></div>
       </aside>
     </div>
 
     <section class="musicChatPanel" id="musicChatPanel">
       <header><strong>Room Chat</strong></header>
-      <div class="musicChatMessages"><p><b>Nora:</b> this drop is perfect</p><p><b>Axel:</b> syncing lyrics now 🎤</p></div>
+      <div class="musicChatMessages"><p><b>System:</b> Music playback is shared across the room.</p></div>
     </section>
 
     <nav class="musicRoomMobileTabs" aria-label="Music room sections">

--- a/public/styles.css
+++ b/public/styles.css
@@ -16890,6 +16890,8 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
 .musicQueueList img{width:40px;height:40px;border-radius:8px}.musicQueueList strong{display:block;font-size:13px}.musicQueueList span{font-size:12px;color:#a8b0c3}
 .musicQueueActions button{background:transparent;border:0;color:#d6ddf0;cursor:pointer}
 .musicPlayerSection{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:20px;gap:14px}
+.musicPlayerSection #musicPlayerFrame{width:min(920px,100%);aspect-ratio:16/9;border-radius:14px;overflow:hidden;background:#000}
+.musicPlayerSection #musicPlayerFrame iframe{width:100%!important;height:100%!important}
 .musicAlbumArt{width:min(100%,420px);aspect-ratio:1}.musicAlbumArt img{width:100%;height:100%;object-fit:cover;border-radius:22px;box-shadow:0 16px 35px rgba(0,0,0,.5)}
 .musicTrackMeta h3{margin:0;font-size:30px}.musicTrackMeta p{margin:4px 0 0;color:#9aa5bc}
 .musicProgressWrap{width:min(560px,100%)}.musicProgressBar{height:6px;background:rgba(255,255,255,.14);border-radius:999px;overflow:hidden}.musicProgressBar span{display:block;height:100%;background:linear-gradient(90deg,#14b8a6,#8b5cf6)}


### PR DESCRIPTION
### Motivation
- Consolidate two parallel music UIs so the new pixel-perfect music-room modal is the single source of truth on desktop and mobile.
- Surface read-only timestamps so users can see playback progress without giving seek control.
- Make the lyrics button actually fetch and show lyrics using the existing server flow and cache results per track.
- Improve reliability for late joiners by ensuring metadata (artist, albumArt, duration) is always passed to the player.

### Description
- Rewired `MusicRoomPlayer` to bind to the existing modal (`#musicRoomExperienceModal`) instead of creating/using the floating mini-player, and made the modal the primary desktop presentation (changes in `public/app.js` and `public/index.html`).
- Eliminated duplicate lyrics targeting by renaming the modal lyrics element to `musicRoomLyricsPanel` and exposing a single lyrics content node `musicLyricsContent`; updated all UI toggles to target that element only (HTML + JS updates).
- Added a read-only time display `musicTimeDisplay` and updated the sync badge to show `mm:ss / mm:ss`; implemented `formatClock` + `refreshTimeDisplay` + a per-second ticker that updates during playback without adding any seek controls (all in `public/app.js`).
- Wired the lyrics button to reuse the existing socket `music:lyrics:get` flow with a client-side `lyricsCache`, showing `Loading lyrics...`, the fetched lyrics, or `Lyrics unavailable.` as a fallback; caching avoids repeated fetches during the session (`public/app.js`).
- Fixed late-join hydration in `joinRoom("music")` so `MusicRoomPlayer.playVideo(...)` receives `artist`, `albumArt`, and `duration` from `music:getState`, preventing metadata loss for late joiners (`public/app.js`).
- Expanded player frame styling to make the modal player larger and cleaner on desktop and ensured the YouTube iframe scales to the modal (`public/styles.css`).
- Preserved the server-driven sync model (`startedAt` + periodic `music:sync`/`music:play`/`music:pause`/`music:resume`) and kept drift correction logic intact while avoiding double-triggered loads or new seek controls.

### Testing
- Ran `node --check public/app.js` to validate the client script syntax; the check succeeded.
- Ran `node --check server.js` to validate server-side syntax; the check succeeded.
- Performed a repository consistency check (local file changes present and staged); checks completed without runtime errors.

If you want, I can run a quick manual smoke test script to simulate socket events (play/sync/pause/resume/lyrics) in a headless environment next.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73f6e25b883338faf26ff2455ce28)