### PR TITLE
Fix Music Room YouTube UI rendering and shared API loader

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7339,10 +7339,27 @@ function formatTime(ts){
     return `${hh}:${mm}`;
   }
 }
+
+window._ytApiPromise = window._ytApiPromise || null;
+function loadYouTubeApi(){
+  if(window.YT?.Player) return Promise.resolve(window.YT);
+  if(window._ytApiPromise) return window._ytApiPromise;
+  window._ytApiPromise = new Promise((resolve, reject)=>{
+    const prevCb = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = ()=>{ prevCb?.(); resolve(window.YT); };
+    const existingScript = document.querySelector('script[src="https://www.youtube.com/iframe_api"]');
+    if(existingScript) return;
+    const script = document.createElement("script");
+    script.src = "https://www.youtube.com/iframe_api";
+    script.async = true;
+    script.onerror = ()=>reject(new Error("yt-api-load-failure"));
+    document.head.appendChild(script);
+  });
+  return window._ytApiPromise;
+}
 const StickyYouTubePlayer = (()=>{
   let container, playerHolder, titleEl, channelEl, thumbEl, playPauseBtn, muteBtn, volumeSlider, seekSlider, currentTimeEl, durationEl, qualitySelect, minimizeBtn, closeBtn, audioOnlyCheckbox, waveformCanvas;
   let player = null;
-  let apiReadyPromise = null;
   let progressTimer = null;
   let currentVideoId = null;
   let pendingAutoplay = false;
@@ -7469,21 +7486,6 @@ const StickyYouTubePlayer = (()=>{
   }
 
 
-  function loadApi(){
-    if(window.YT?.Player) return Promise.resolve(window.YT);
-    if(apiReadyPromise) return apiReadyPromise;
-    apiReadyPromise = new Promise((resolve, reject)=>{
-      const prevCb = window.onYouTubeIframeAPIReady;
-      window.onYouTubeIframeAPIReady = ()=>{ prevCb?.(); resolve(window.YT); };
-      const script = document.createElement("script");
-      script.src = "https://www.youtube.com/iframe_api";
-      script.async = true;
-      script.onerror = (err)=>reject(err);
-      document.head.appendChild(script);
-    });
-    return apiReadyPromise;
-  }
-
   function initDom(){
     container = document.getElementById("ytSticky");
     if(!container) return;
@@ -7571,7 +7573,7 @@ const StickyYouTubePlayer = (()=>{
 
   function ensurePlayer(){
     if(player) return Promise.resolve(player);
-    return loadApi().then(()=>{
+    return loadYouTubeApi().then(()=>{
       player = new YT.Player(playerHolder, {
         height: "180",
         width: "320",
@@ -7896,7 +7898,6 @@ const MusicRoomPlayer = (() => {
 
   let lyricsPanelEl = null;
   let lyricsVisible = false;
-  let apiReadyPromise = null;
   let currentVideo = null;
   let queue = [];
   let isLoadingVideo = false; // Track if a video is currently being loaded
@@ -7962,21 +7963,6 @@ const MusicRoomPlayer = (() => {
   let listenersAttached = false;
   let mouseMoveHandler = null;
   let mouseUpHandler = null;
-
-  function loadApi() {
-    if (window.YT?.Player) return Promise.resolve(window.YT);
-    if (apiReadyPromise) return apiReadyPromise;
-    apiReadyPromise = new Promise((resolve, reject) => {
-      const prevCb = window.onYouTubeIframeAPIReady;
-      window.onYouTubeIframeAPIReady = () => { prevCb?.(); resolve(window.YT); };
-      const script = document.createElement("script");
-      script.src = "https://www.youtube.com/iframe_api";
-      script.async = true;
-      script.onerror = (err) => reject(err);
-      document.head.appendChild(script);
-    });
-    return apiReadyPromise;
-  }
 
   function initDom() {
     if (playerContainer) return;
@@ -8402,13 +8388,17 @@ const MusicRoomPlayer = (() => {
   async function ensurePlayer() {
     if (player) return player;
     
-    await loadApi();
+    await loadYouTubeApi();
     const playerFrame = document.getElementById("music-room-player");
     if (!playerFrame) return null;
     
-    player = new YT.Player(playerFrame, {
-      height: "158",
-      width: "280",
+    playerFrame.innerHTML = "";
+    const mountNode = document.createElement("div");
+    playerFrame.appendChild(mountNode);
+
+    player = new YT.Player(mountNode, {
+      height: "100%",
+      width: "100%",
       host: "https://www.youtube-nocookie.com",
       playerVars: { 
         playsinline: 1, 
@@ -8813,12 +8803,15 @@ const MusicRoomPlayer = (() => {
 function buildYouTubePreview(videoId){
   const root = document.createElement("div");
   root.className = "ytEmbedHost";
-  if(!window.YouTubeEmbed){
-    root.textContent = "YouTube player unavailable.";
-    return root;
+  function tryMount(){
+    if(!window.YouTubeEmbed){
+      setTimeout(tryMount, 50);
+      return;
+    }
+    const cached = YOUTUBE_META_CACHE.get(videoId) || {};
+    new window.YouTubeEmbed(root, { videoId, meta: cached });
   }
-  const cached = YOUTUBE_META_CACHE.get(videoId) || {};
-  new window.YouTubeEmbed(root, { videoId, meta: cached });
+  tryMount();
   return root;
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -16867,6 +16867,8 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
 
 @media (min-width: 769px) and (max-width: 1024px){ .topbar{ padding:0 var(--space-3); } }
 @media (min-width: 1025px){ .topbar{ padding:0 var(--space-3); } }
+.ytEmbedHost{display:block;width:100%;}
+.ytEmbed{display:block;position:relative;width:100%;}
 .ytEmbedAspect{position:relative;aspect-ratio:16/9;width:100%;background:#111;border-radius:12px;overflow:hidden}
 .ytEmbedPoster,.ytEmbedPlayer,.ytEmbedPlayer iframe,.ytEmbedError{position:absolute;inset:0;width:100%;height:100%}
 .ytEmbedPoster{background-size:cover;background-position:center;border:0;cursor:pointer}

--- a/public/youtube-embed.js
+++ b/public/youtube-embed.js
@@ -5,11 +5,14 @@
   const activePlayers = new Set();
 
   function loadApi(){
+    if(global.loadYouTubeApi) return global.loadYouTubeApi();
     if(global.YT?.Player) return Promise.resolve(global.YT);
     if(apiPromise) return apiPromise;
     apiPromise = new Promise((resolve, reject)=>{
       const prev = global.onYouTubeIframeAPIReady;
       global.onYouTubeIframeAPIReady = () => { prev?.(); resolve(global.YT); };
+      const existingScript = document.querySelector(`script[src="${API_SRC}"]`);
+      if(existingScript) return;
       const script = document.createElement('script');
       script.src = API_SRC;
       script.async = true;


### PR DESCRIPTION
### Motivation
- The YouTube iframe and preview embeds were not rendering because the IFrame API replaced styled container nodes and CSS-based sizing was ignored.  
- Multiple independent YouTube API loaders created a race on `window.onYouTubeIframeAPIReady`, leaving some players pending.  
- The preview builder could run before `YouTubeEmbed` was available causing silent fallback to plain text.  
- `.ytEmbed` wrappers lacked base layout rules and collapsed to zero size.

### Description
- Introduced a single shared API loader `loadYouTubeApi()` (backed by `window._ytApiPromise`) at the top of `public/app.js` and switched existing consumers to call it, removing duplicate local `loadApi()` implementations.  
- Updated Music Room `ensurePlayer()` to preserve `#music-room-player` as the CSS-sized container, mount the YT iframe into a newly created child `div`, and use `height: "100%"`/`width: "100%"` so the iframe fills the container.  
- Made `buildYouTubePreview()` defensively retry mounting until `window.YouTubeEmbed` is defined instead of failing immediately.  
- Modified `public/youtube-embed.js` to prefer the shared `window.loadYouTubeApi()` when present and kept a standalone fallback for independent usage.  
- Added base CSS rules for `.ytEmbedHost` and `.ytEmbed` to ensure block layout and full width so embed wrappers do not collapse.

### Testing
- Ran `node --check public/app.js` and `node --check public/youtube-embed.js`, both succeeded.  
- Verified relevant symbols and updates using `rg` to ensure `loadYouTubeApi`, mount-node changes, and `buildYouTubePreview` retry logic were applied.  
- Confirmed `public/styles.css` contains the new `.ytEmbedHost` and `.ytEmbed` rules and that the modified files parse without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74f6728808333b56fd465ae9f1135)